### PR TITLE
improved testing

### DIFF
--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -110,12 +110,14 @@ class Market:
         self.check_action_type(agent_action.action_type, pricing_model.model_name())
         # TODO: check the desired amount is feasible, otherwise return descriptive error
         # update market variables which may have changed since the user action was created
+        logging.debug("evaluating time_remaining for agent_action %s at time %s", agent_action, self.time)
+        # set mint time to current time if not specified
+        action_mint_time = agent_action.mint_time if agent_action.mint_time is not None else self.time
+        time_remaining = time_utils.get_yearfrac_remaining(self.time, action_mint_time, self.token_duration)
+        stretched_time_remaining = time_utils.stretch_time(time_remaining, self.time_stretch_constant)
         time_remaining = StretchedTime(
-            # TODO: We should improve the StretchedTime API so that it accepts yearfracs in
-            # the place of days remaining.
-            days=time_utils.get_yearfrac_remaining(
-                self.time, agent_action.mint_time, self.position_duration.normalized_days
-            )
+            # TODO: We should improve the StretchedTime API so that it accepts yearfracs in the place of days remaining.
+            days=time_utils.get_yearfrac_remaining(self.time, action_mint_time, self.position_duration.normalized_days)
             * 365,
             time_stretch=self.position_duration.time_stretch,
         )

--- a/src/elfpy/pricing_models.py
+++ b/src/elfpy/pricing_models.py
@@ -1,0 +1,1401 @@
+"""
+Pricing models implement automated market makers (AMMs)
+"""
+
+from abc import ABC, abstractmethod
+from typing import NamedTuple
+import logging
+
+from elfpy.types import TokenType
+import elfpy.utils.price as price_utils
+import elfpy.utils.time as time_utils
+
+# TODO: Currently many functions use >5 arguments.
+# These should be packaged up into shared variables, e.g.
+#     reserves = (in_reserves, out_reserves)
+#     share_prices = (init_share_price, share_price)
+# pylint: disable=too-many-arguments
+
+# TODO: This module is too big, we should break it up into pricing_models/{base.py, element.py, hyperdrive.py}
+# pylint: disable=too-many-lines
+
+# TODO: some functions have too many local variables (15 is recommended max),
+#     we should consider how to break them up or delete this TODO if it's not possible
+# pylint: disable=too-many-locals
+
+
+class TradeResult(NamedTuple):
+    """
+    Result from a calc_out_given_in or calc_in_given_out.  The values are the amount of asset required
+    for the trade, either in or out.  Fee is the amount of fee collected, if any.
+    """
+
+    without_fee_or_slippage: float
+    with_fee: float
+    without_fee: float
+    fee: float
+
+
+class PricingModel(ABC):
+    """
+    Contains functions for calculating AMM variables
+
+    Base class should not be instantiated on its own; it is assumed that a user will instantiate a child class
+    """
+
+    # TODO: Change argument defaults to be None & set inside of def to avoid accidental overwrite
+    # TODO: set up member object that owns attributes instead of so many individual instance attributes
+    # pylint: disable=too-many-instance-attributes
+
+    @abstractmethod
+    def calc_in_given_out(
+        self,
+        out: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_in: TokenType,
+        fee_percent: float,
+        stretched_time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
+        """Calculate fees and asset quantity adjustments"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def calc_out_given_in(
+        self,
+        in_: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_out: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
+        """Calculate fees and asset quantity adjustments"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def calc_lp_out_given_tokens_in(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        """
+        Computes the amount of LP tokens to be minted for a given amount of base asset"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def calc_lp_in_given_tokens_out(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        """
+        Computes the amount of LP tokens to be minted for a given amount of base asset"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def calc_tokens_out_given_lp_in(
+        self,
+        lp_in: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        """Calculate how many tokens should be returned for a given lp addition"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def model_name(self) -> str:
+        """Unique name given to the model, can be based on member variable states"""
+        raise NotImplementedError
+
+    def calc_spot_price_from_reserves(
+        self,
+        share_reserves: float,
+        bond_reserves: float,
+        init_share_price: float,
+        share_price: float,
+        time_remaining: float,
+    ) -> float:
+        r"""
+        Calculates the spot price of base in terms of bonds.
+
+        The spot price is defined as:
+
+        .. math::
+            \begin{align}
+            p = (\frac{2y + cz}{\mu z})^{-\tau}
+            \end{align}
+
+        Arguments
+        ---------
+        share_reserves : float
+            The reserves of shares in the pool.
+        bond_reserves : float
+            The reserves of bonds in the pool.
+        init_share_price : float
+            The share price when the pool was initialized.
+        share_price : float
+            The current share price.
+        time_remaining : float
+            The time remaining for the asset (incorporates time stretch).
+
+        Returns
+        -------
+        float
+            The spot price of principal tokens.
+        """
+        assert share_reserves > 0, (
+            f"pricing_models.calc_spot_price_from_reserves: ERROR: expected share_reserves > 0, not {share_reserves}!",
+        )
+        total_reserves = share_price * share_reserves + bond_reserves
+        bond_reserves_ = bond_reserves + total_reserves
+        spot_price = 1 / (((bond_reserves_) / (init_share_price * share_reserves)) ** time_remaining)
+        return spot_price
+
+    def calc_apr_from_reserves(
+        self,
+        share_reserves: float,
+        bond_reserves: float,
+        time_remaining: float,
+        time_stretch: float,
+        init_share_price: float = 1,
+        share_price: float = 1,
+    ) -> float:
+        # TODO: Update this comment so that it matches the style of the other comments.
+        """
+        Returns the apr given reserve amounts
+        """
+        spot_price = self.calc_spot_price_from_reserves(
+            share_reserves,
+            bond_reserves,
+            init_share_price,
+            share_price,
+            time_remaining,
+        )
+        days_remaining = time_utils.time_to_days_remaining(time_remaining, time_stretch)
+        apr = price_utils.calc_apr_from_spot_price(spot_price, time_utils.norm_days(days_remaining))
+        return apr
+
+    def calc_time_stretch(self, apr):
+        """Returns fixed time-stretch value based on current apr (as a decimal)"""
+        apr_percent = apr * 100
+        return 3.09396 / (0.02789 * apr_percent)
+
+
+class ElementPricingModel(PricingModel):
+    """
+    Element v1 pricing model
+    Does not use the Yield Bearing Vault `init_share_price` (μ) and `share_price` (c) variables.
+    """
+
+    def calc_lp_out_given_tokens_in(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        raise NotImplementedError
+
+    def calc_lp_in_given_tokens_out(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        raise NotImplementedError
+
+    def calc_tokens_out_given_lp_in(
+        self,
+        lp_in: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        raise NotImplementedError
+
+    def model_name(self) -> str:
+        return "Element"
+
+    def calc_in_given_out(
+        self,
+        out: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_in: TokenType,
+        fee_percent: float,
+        stretched_time_remaining: float,
+        init_share_price=1.0,
+        share_price=1.0,
+    ) -> TradeResult:
+        r"""
+        Calculates the amount of an asset that must be provided to receive a
+        specified amount of the other asset given the current AMM reserves.
+
+        The input is calculated as:
+
+        .. math::
+            in' =
+            \begin{cases}
+            (\frac{k - (2y + x - \Delta y)^{1 - \tau}})^{\frac{1}{1 - \tau}} -
+             x, &\text{ if } token\_in = \text{"base"} \\
+            (k - (x - \Delta x)^{1 - \tau})^{\frac{1}{1 - \tau}} - (2y + x), &\text{ if } token\_in = \text{"pt"}
+            \end{cases} \\
+            f =
+            \begin{cases}
+            (\Delta y - in') \cdot \phi, &\text{ if } token\_in = \text{"base"} \\
+            (in' - \Delta x) \cdot \phi, &\text{ if } token\_in = \text{"pt"}
+            \end{cases} \\
+            in = in' + f
+
+        Arguments
+        ---------
+        out : float
+            The amount of tokens that the user wants to receive. When the user
+            wants to pay in bonds, this value should be an amount of base tokens
+            rather than an amount of shares.
+        share_reserves : float
+            The reserves of shares in the pool. NOTE: Element V1 didn't have a
+            concept of shares and instead used base.
+        bond_reserves : float
+            The reserves of bonds in the pool.
+        token_in : str
+            The token that the user pays. The only valid values are "base" and
+            "pt".
+        fee_percent : float
+            The percentage of the difference between the amount paid without
+            slippage and the amount received that will be added to the input
+            as a fee.
+        time_remaining : float
+            The time remaining for the asset (incorporates time stretch).
+        init_share_price : float
+            The share price when the pool was initialized. NOTE: For this
+            pricing model, the initial share price must always be one.
+        share_price : float
+            The current share price. NOTE: For this pricing model, the share
+            price must always be one.
+
+        Returns
+        -------
+        float
+            The amount the user pays without fees or slippage. The units
+            are always in terms of bonds or base.
+        float
+            The amount the user pays with fees and slippage. The units are
+            always in terms of bonds or base.
+        float
+            The amount the user pays with slippage and no fees. The units are
+            always in terms of bonds or base.
+        float
+            The fee the user pays. The units are always in terms of bonds or
+            base.
+        """
+
+        assert out > 0, f"pricing_models.calc_in_given_out: ERROR: expected out > 0, not {out}!"
+        assert (
+            share_reserves >= 0
+        ), f"pricing_models.calc_in_given_out: ERROR: expected share_reserves >= 0, not {share_reserves}!"
+        assert (
+            bond_reserves >= 0
+        ), f"pricing_models.calc_in_given_out: ERROR: expected bond_reserves >= 0, not {bond_reserves}!"
+        assert (
+            1 >= fee_percent >= 0
+        ), f"pricing_models.calc_in_given_out: ERROR: expected 1 >= fee_percent >= 0, not {fee_percent}!"
+        assert 1 > stretched_time_remaining >= 0, (
+            "pricing_models.calc_in_given_out: ERROR: expected 1 > stretched_time_remaining >= 0,"
+            + f" not {stretched_time_remaining}!"
+        )
+        assert share_price == init_share_price == 1, (
+            "pricing_models.calc_in_given_out: ERROR: expected share_price == init_share_price == 1,"
+            f"not share_price={share_price} and init_share_price={init_share_price}!"
+        )
+
+        time_elapsed = 1 - stretched_time_remaining
+        bond_reserves_ = 2 * bond_reserves + share_reserves
+        spot_price = self.calc_spot_price_from_reserves(share_reserves, bond_reserves, 1, 1, stretched_time_remaining)
+        # We precompute the YieldSpace constant k using the current reserves and
+        # share price:
+        #
+        # k = (c / μ) * (μ * z)**(1 - t) + (2y + cz)**(1 - t)
+        k = price_utils.calc_k_const(share_reserves, bond_reserves, share_price, init_share_price, time_elapsed)
+        # Solve for the amount that must be paid to receive the specified amount
+        # of the output.
+        if token_in == "base":
+            d_bonds = out
+            # The amount the user pays without fees or slippage is the amount of
+            # bonds the user receives times the spot price of base in terms
+            # of bonds. If we let p be the conventional spot price, then we can
+            # write this as:
+            #
+            # without_fee_or_slippage = p * d_y
+            without_fee_or_slippage = spot_price * d_bonds
+            # We solve the YieldSpace invariant for the base required to
+            # purchase the requested amount of bonds. We set up the invariant
+            # where the user pays d_x' base and receives d_y bonds:
+            #
+            # (x + d_x')**(1 - t) + (2y + x - d_y)**(1 - t) = k
+            #
+            # Solving for d_x' gives us the amount of base the user must pay
+            # without including fees:
+            #
+            # d_x' = (k - (2y + x - d_y)**(1 - t))**(1 / (1 - t)) - x
+            #
+            # without_fee = d_x'
+            without_fee = (k - (bond_reserves_ - d_bonds) ** time_elapsed) ** (1 / time_elapsed) - share_reserves
+            # The fees are calculated as the difference between the bonds
+            # received and the base paid without fees times the fee percentage.
+            # This can also be expressed as:
+            #
+            # fee = phi * (d_y - d_x')
+            fee = fee_percent * (d_bonds - without_fee)
+        elif token_in == "pt":
+            d_base = out
+            # The amount the user pays without fees or slippage is the amount of
+            # bonds the user receives times the inverse of the spot price
+            # of base in terms of bonds. If we let p be the conventional spot
+            # price, then we can write this as:
+            #
+            # without_fee_or_slippage = (1 / p) * d_x
+            without_fee_or_slippage = (1 / spot_price) * out
+            # We solve the YieldSpace invariant for the bonds required to
+            # purchase the requested amount of base. We set up the invariant
+            # where the user pays d_y bonds and receives d_x base:
+            #
+            # (x - d_x)**(1 - t) + (2y + x + d_y')**(1 - t) = k
+            #
+            # Solving for d_y' gives us the amount of bonds the user must pay
+            # without including fees:
+            #
+            # d_y' = (k - (x - d_x)**(1 - t))**(1 / (1 - t)) - (2y + x)
+            #
+            # without_fee = d_y'
+            without_fee = (k - (share_reserves - d_base) ** time_elapsed) ** (1 / time_elapsed) - bond_reserves_
+            # The fees are calculated as the difference between the bonds
+            # paid without fees and the base received times the fee percentage.
+            # This can also be expressed as:
+            #
+            # fee = phi * (d_y' - d_x)
+            fee = fee_percent * (without_fee - d_base)
+        else:
+            raise AssertionError(
+                f'pricing_models.calc_in_given_out: ERROR: expected token_in to be "base" or "pt", not {token_in}!'
+            )
+        # To get the amount paid with fees, add the fee to the calculation that
+        # excluded fees. Adding the fees results in more tokens paid, which
+        # indicates that the fees are working correctly.
+        with_fee = without_fee + fee
+        # TODO(jalextowle): With some analysis, it seems possible to show that
+        # we skip straight from non-negative reals to the complex plane without
+        # hitting negative reals.
+        #
+        # Ensure that the outputs are all non-negative floats. We only need to
+        # check without_fee since without_fee_or_slippage will always be a positive
+        # float due to the constraints on the inputs, with_fee = without_fee + fee
+        # so it is a positive float if without_fee and fee are positive floats, and
+        # fee is a positive float due to the constraints on the inputs.
+        assert isinstance(
+            without_fee, float
+        ), f"pricing_models.calc_in_given_out: ERROR: without_fee should be a float, not {type(without_fee)}!"
+        assert (
+            without_fee >= 0
+        ), f"pricing_models.calc_in_given_out: ERROR: without_fee should be non-negative, not {without_fee}!"
+        logging.debug(
+            (
+                "\n\tout = %g\n\tshare_reserves = %d\n\tbond_reserves = %d"
+                "\n\ttotal_reserves = %d\n\tinit_share_price = %g"
+                "\n\tshare_price = %d\n\tfee_percent = %g"
+                "\n\ttime_remaining = %g\n\ttime_elapsed = %g"
+                "\n\ttoken_in = %s\n\tspot_price = %g"
+                "\n\tk = %g\n\twithout_fee_or_slippage = %g"
+                "\n\twithout_fee = %g\n\twith_fee = %g\n\tfee = %g"
+            ),
+            out,
+            share_reserves,
+            bond_reserves,
+            share_reserves + bond_reserves,
+            init_share_price,
+            share_price,
+            fee_percent,
+            stretched_time_remaining,
+            time_elapsed,
+            token_in,
+            spot_price,
+            k,
+            without_fee_or_slippage,
+            without_fee,
+            with_fee,
+            fee,
+        )
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)
+
+    def calc_out_given_in(
+        self,
+        in_: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_out: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float = 1.0,
+        share_price: float = 1.0,
+    ) -> TradeResult:
+        r"""
+        Calculates the amount of an asset that must be provided to receive a
+        specified amount of the other asset given the current AMM reserves.
+
+        The output is calculated as:
+
+        .. math::
+            out' =
+            \begin{cases}
+            (x - (k - (2y + x + \Delta y)^{1 - \tau})^{\frac{1}{1 - \tau}}), &\text{ if } token\_out = \text{"base"} \\
+            2y + x - (k - (x + \Delta x)^{1 - \tau})^{\frac{1}{1 - \tau}}, &\text{ if } token\_out = \text{"pt"}
+            \end{cases} \\
+            f =
+            \begin{cases}
+            (\Delta y - out') \cdot \phi, &\text{ if } token\_out = \text{"base"} \\
+            (out' - \Delta x) \cdot \phi, &\text{ if } token\_out = \text{"pt"}
+            \end{cases} \\
+            out = out' + f
+
+        Arguments
+        ---------
+        in_ : float
+            The amount of tokens that the user pays. When users receive bonds,
+            this value reflects the base paid.
+        share_reserves : float
+            The reserves of base in the pool.
+        bond_reserves : float
+            The reserves of bonds (PT) in the pool.
+        token_out : str
+            The token that the user receives. The only valid values are "base"
+            and "pt".
+        fee_percent : float
+            The percentage of the difference between the amount paid and the
+            amount received without slippage that will be debited from the
+            output as a fee.
+        time_remaining : float
+            The time remaining for the asset (incorporates time stretch).
+        init_share_price : float
+            The share price when the pool was initialized. NOTE: For this
+            pricing model, the initial share price must always be one.
+        share_price : float
+            The current share price. NOTE: For this pricing model, the share
+            price must always be one.
+
+        Returns
+        -------
+        float
+            The amount the user receives without fees or slippage. The units
+            are always in terms of bonds or base.
+        float
+            The amount the user receives with fees and slippage. The units are
+            always in terms of bonds or base.
+        float
+            The amount the user receives with slippage and no fees. The units are
+            always in terms of bonds or base.
+        float
+            The fee the user pays. The units are always in terms of bonds or
+            base.
+        """
+        assert in_ > 0, f"pricing_models.calc_out_given_in: ERROR: expected in_ > 0, not {in_}!"
+        assert (
+            share_reserves >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected share_reserves >= 0, not {share_reserves}!"
+        assert (
+            bond_reserves >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected bond_reserves >= 0, not {bond_reserves}!"
+        assert (
+            1 >= fee_percent >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected 1 >= fee_percent >= 0, not {fee_percent}!"
+        assert (
+            1 > time_remaining >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected 1 > time_remaining >= 0, not {time_remaining}!"
+        assert share_price == init_share_price == 1, (
+            "pricing_models.calc_out_given_in: ERROR: expected share_price == init_share_price == 1,"
+            f"not share_price={share_price} and init_share_price={init_share_price}!"
+        )
+
+        time_elapsed = 1 - time_remaining
+        bond_reserves_ = 2 * bond_reserves + share_reserves
+        spot_price = self.calc_spot_price_from_reserves(share_reserves, bond_reserves, 1, 1, time_remaining)
+        # We precompute the YieldSpace constant k using the current reserves and
+        # share price:
+        #
+        # k = x**(1 - t) + (2y + x)**(1 - t)
+        k = price_utils.calc_k_const(share_reserves, bond_reserves, share_price, init_share_price, time_elapsed)
+        # Solve for the amount that received if the specified amount is paid.
+        if token_out == "base":
+            d_bonds = in_
+            # The amount the user pays without fees or slippage is the amount of
+            # bonds the user pays times the spot price of base in terms of bonds.
+            # If we let p be the conventional spot price, then we can write this
+            # as:
+            #
+            # without_fee_or_slippage = p * d_y
+            without_fee_or_slippage = spot_price * d_bonds
+            # We solve the YieldSpace invariant for the base received from
+            # paying the specified amount of bonds. We set up the invariant
+            # where the user pays d_y bonds and receives d_x' base:
+            #
+            # (x - d_x')**(1 - t) + (2y + x + d_y)**(1 - t) = k
+            #
+            # Solving for d_x' gives us the amount of base the user must pay
+            # without including fees:
+            #
+            # d_x' = x - (k - (2y + x + d_y)**(1 - t))**(1 / (1 - t))
+            #
+            # without_fee = d_x'
+            without_fee = share_reserves - (k - (bond_reserves_ + d_bonds) ** time_elapsed) ** (1 / time_elapsed)
+            # The fees are calculated as the difference between the bonds paid
+            # and the base received without fees times the fee percentage. This
+            # can also be expressed as:
+            #
+            # fee = phi * (d_y - d_x')
+            fee = fee_percent * (d_bonds - without_fee)
+        elif token_out == "pt":
+            d_base = in_
+            # The amount the user pays without fees or slippage is the amount of
+            # base the user pays times the inverse of the spot price of base in
+            # terms of bonds. If we let p be the conventional spot price, then
+            # we can write this as:
+            #
+            # without_fee_or_slippage = (1 / p) * d_x
+            without_fee_or_slippage = (1 / spot_price) * d_base
+            # We solve the YieldSpace invariant for the bonds received from
+            # paying the specified amount of base. We set up the invariant
+            # where the user pays d_x base and receives d_y' bonds:
+            #
+            # (x + d_x)**(1 - t) + (2y + x - d_y')**(1 - t) = k
+            #
+            # Solving for d_x' gives us the amount of base the user must pay
+            # without including fees:
+            #
+            # d_y' = 2y + x - (k - (x + d_x)**(1 - t))**(1 / (1 - t))
+            #
+            # without_fee = d_x'
+            without_fee = bond_reserves_ - (k - (share_reserves + d_base) ** time_elapsed) ** (1 / time_elapsed)
+            # The fees are calculated as the difference between the bonds paid
+            # and the base received without fees times the fee percentage. This
+            # can also be expressed as:
+            #
+            # fee = phi * (d_y' - d_x)
+            fee = fee_percent * (without_fee - d_base)
+        else:
+            raise AssertionError(
+                f'pricing_models.calc_out_given_in: ERROR: expected token_out to be "base" or "pt", not {token_out}!'
+            )
+        # To get the amount paid with fees, subtract the fee from the
+        # calculation that excluded fees. Subtracting the fees results in less
+        # tokens received, which indicates that the fees are working correctly.
+        with_fee = without_fee - fee
+        # TODO(jalextowle): With some analysis, it seems possible to show that
+        # we skip straight from non-negative reals to the complex plane without
+        # hitting negative reals.
+        #
+        # Ensure that the outputs are all non-negative floats. We only need to
+        # check with_fee since without_fee_or_slippage will always be a positive
+        # float due to the constraints on the inputs, without_fee = with_fee + fee
+        # so it is a positive float if with_fee and fee are positive floats, and
+        # fee is a positive float due to the constraints on the inputs.
+        assert isinstance(
+            with_fee, float
+        ), f"pricing_models.calc_out_given_in: ERROR: with_fee should be a float, not {type(with_fee)}!"
+        assert (
+            with_fee >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: with_fee should be non-negative, not {with_fee}!"
+        logging.debug(
+            (
+                "\n\tin_ = %g\n\tshare_reserves = %d\n\tbond_reserves = %d"
+                "\n\ttotal_reserves = %d\n\tinit_share_price = %g"
+                "\n\tshare_price = %g\n\tfee_percent = %g"
+                "\n\ttime_remaining = %g\n\ttime_elapsed = %g"
+                "\n\ttoken_out = %s\n\tspot_price = %g"
+                "\n\tk = %g\n\twithout_fee_or_slippage = %g"
+                "\n\twithout_fee = %g\n\twith_fee = %g\n\tfee = %g"
+            ),
+            in_,
+            share_reserves,
+            bond_reserves,
+            share_reserves + bond_reserves,
+            init_share_price,
+            share_price,
+            fee_percent,
+            time_remaining,
+            time_elapsed,
+            token_out,
+            spot_price,
+            k,
+            without_fee_or_slippage,
+            without_fee,
+            with_fee,
+            fee,
+        )
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)
+
+
+class HyperdrivePricingModel(PricingModel):
+    """
+    Hyperdrive Pricing Model
+
+    This pricing model uses the YieldSpace invariant with modifications to
+    enable the base reserves to be deposited into yield bearing vaults
+    """
+
+    def model_name(self) -> str:
+        return "Hyperdrive"
+
+    def calc_lp_out_given_tokens_in(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        r"""
+        Computes the amount of LP tokens to be minted for a given amount of base asset
+
+        .. math::
+
+        y = \frac{(z + \Delta z)(\mu \cdot (\frac{1}{1 + r \cdot t(d)})^{\frac{1}{\tau(d_b)}} - c)}{2}
+
+        """
+        assert d_base > 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected d_base > 0, not {d_base}!"
+        assert (
+            share_reserves >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected share_reserves >= 0, not {share_reserves}!"
+        assert (
+            bond_reserves >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected bond_reserves >= 0, not {bond_reserves}!"
+        assert (
+            share_buffer >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected share_buffer >= 0, not {share_buffer}!"
+        assert (
+            lp_reserves >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected lp_reserves >= 0, not {lp_reserves}!"
+        assert rate >= 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected rate >= 0, not {rate}!"
+        assert (
+            1 > time_remaining >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected 1 > time_remaining >= 0, not {time_remaining}!"
+        assert stretched_time_remaining >= 0, (
+            "pricing_models.calc_lp_out_given_tokens_in: ERROR: expected stretched_time_remaining >= 0,"
+            f"not {stretched_time_remaining}!"
+        )
+        assert share_price >= init_share_price >= 1, (
+            "pricing_models.calc_lp_out_given_tokens_in: ERROR: expected share_price >= init_share_price >= 1, not"
+            f" share_price={share_price} and init_share_price={init_share_price}!"
+        )
+        d_shares = d_base / share_price
+        if share_reserves > 0:  # normal case where we have some share reserves
+            lp_out = (d_shares * lp_reserves) / (share_reserves - share_buffer)
+        else:  # initial case where we have 0 share reserves or final case where it has been removed
+            lp_out = d_shares
+        d_bonds = (share_reserves + d_shares) / 2 * (
+            init_share_price * (1 + rate * time_remaining) ** (1 / stretched_time_remaining) - share_price
+        ) - bond_reserves
+        logging.debug(
+            (
+                "inputs: d_base=%g, share_reserves=%d, "
+                "bond_reserves=%d, share_buffer=%g, "
+                "init_share_price=%g, share_price=%g, "
+                "lp_reserves=%g, rate=%g, "
+                "time_remaining=%g, stretched_time_remaining=%g"
+                "\nd_shares=%g (d_base / share_price = %g / %g)"
+                "\nlp_out=%g\n"
+                "(d_share_reserves * lp_reserves / (share_reserves - share_buffer) = "
+                "%g * %g / (%g - %g))"
+                "\nd_bonds=%g\n"
+                "((share_reserves + d_share_reserves) / 2 * (init_share_price * (1 + rate * time_remaining) ** "
+                "(1 / stretched_time_remaining) - share_price) - bond_reserves = "
+                "(%g + %g) / 2 * (%g * (1 + %g * %g) ** "
+                "(1 / %g) - %g) - %g)"
+            ),
+            d_base,
+            share_reserves,
+            bond_reserves,
+            share_buffer,
+            init_share_price,
+            share_price,
+            lp_reserves,
+            rate,
+            time_remaining,
+            stretched_time_remaining,
+            d_shares,
+            d_base,
+            share_price,
+            lp_out,
+            d_shares,
+            lp_reserves,
+            share_reserves,
+            share_buffer,
+            d_bonds,
+            share_reserves,
+            d_shares,
+            init_share_price,
+            rate,
+            time_remaining,
+            stretched_time_remaining,
+            share_price,
+            bond_reserves,
+        )
+        return lp_out, d_base, d_bonds
+
+    def calc_lp_in_given_tokens_out(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        r"""
+        Computes the amount of LP tokens to be minted for a given amount of base asset
+        .. math::
+        y = \frac{(z - \Delta z)(\mu \cdot (\frac{1}{1 + r \cdot t(d)})^{\frac{1}{\tau(d_b)}} - c)}{2}
+        """
+        assert d_base > 0, f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected d_base > 0, not {d_base}!"
+        assert (
+            share_reserves >= 0
+        ), f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected share_reserves >= 0, not {share_reserves}!"
+        assert (
+            bond_reserves >= 0
+        ), f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected bond_reserves >= 0, not {bond_reserves}!"
+        assert (
+            share_buffer >= 0
+        ), f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected share_buffer >= 0, not {share_buffer}!"
+        assert (
+            lp_reserves >= 0
+        ), f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected lp_reserves >= 0, not {lp_reserves}!"
+        assert rate >= 0, f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected rate >= 0, not {rate}!"
+        assert (
+            1 > time_remaining >= 0
+        ), f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected 1 > time_remaining >= 0, not {time_remaining}!"
+        assert stretched_time_remaining >= 0, (
+            "pricing_models.calc_lp_in_given_tokens_out: ERROR: expected stretched_time_remaining >= 0,"
+            f"not {stretched_time_remaining}!"
+        )
+        assert (
+            share_price >= init_share_price >= 1
+        ), "pricing_models.calc_lp_in_given_tokens_out: ERROR: expected share_price >= init_share_price >= 1, not"
+        d_shares = d_base / share_price
+        lp_in = (d_shares * lp_reserves) / (share_reserves - share_buffer)
+        d_bonds = (share_reserves - d_shares) / 2 * (
+            init_share_price * (1 + rate * time_remaining) ** (1 / stretched_time_remaining) - share_price
+        ) - bond_reserves
+        return lp_in, d_base, d_bonds
+
+    def calc_tokens_out_given_lp_in(
+        self,
+        lp_in: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        """Calculate how many tokens should be returned for a given lp addition"""
+        assert lp_in > 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected lp_in > 0, not {lp_in}!"
+        assert (
+            share_reserves >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected share_reserves >= 0, not {share_reserves}!"
+        assert (
+            bond_reserves >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected bond_reserves >= 0, not {bond_reserves}!"
+        assert (
+            share_buffer >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected share_buffer >= 0, not {share_buffer}!"
+        assert (
+            lp_reserves >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected lp_reserves >= 0, not {lp_reserves}!"
+        assert rate >= 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected rate >= 0, not {rate}!"
+        assert (
+            1 > time_remaining >= 0
+        ), f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected 1 > time_remaining >= 0, not {time_remaining}!"
+        assert stretched_time_remaining >= 0, (
+            "pricing_models.calc_lp_out_given_tokens_in: ERROR: expected stretched_time_remaining >= 0, "
+            f"not {stretched_time_remaining}!"
+        )
+        assert share_price >= init_share_price >= 1, (
+            "pricing_models.calc_lp_out_given_tokens_in: ERROR: expected share_price >= init_share_price >= 1, not"
+            f" share_price={share_price}, and init_share_price={init_share_price}"
+        )
+        d_base = share_price * (share_reserves - share_buffer) * lp_in / lp_reserves
+        d_shares = d_base / share_price
+        d_bonds = (share_reserves - d_shares) / 2 * (
+            init_share_price * (1 + rate * time_remaining) ** (1 / stretched_time_remaining) - share_price
+        ) - bond_reserves
+        logging.debug(
+            (
+                "inputs: lp_in=%g, share_reserves=%d, "
+                "bond_reserves=%d, share_buffer=%g, "
+                "init_share_price=%g, share_price=%g, lp_reserves=%g, "
+                "rate=%g, time_remaining=%g, stretched_time_remaining=%g"
+                "  d_shares=%g (d_base / share_price = %g / %g)"
+                "  d_bonds=%g\n"
+                "((share_reserves + d_share_reserves) / 2 * (init_share_price * (1 + rate * time_remaining) "
+                "** (1 / stretched_time_remaining) - share_price) - bond_reserves = "
+                "(%g + %g) / 2 * (%g * (1 + %g * %g) "
+                "** (1 / %g) - %g) - %g)"
+            ),
+            lp_in,
+            share_reserves,
+            bond_reserves,
+            share_buffer,
+            init_share_price,
+            share_price,
+            lp_reserves,
+            rate,
+            time_remaining,
+            stretched_time_remaining,
+            d_shares,
+            d_base,
+            share_price,
+            d_bonds,
+            share_reserves,
+            d_shares,
+            init_share_price,
+            rate,
+            time_remaining,
+            stretched_time_remaining,
+            share_price,
+            bond_reserves,
+        )
+        return lp_in, d_base, d_bonds
+
+    # TODO: Break this function up to use private class functions
+    # pylint: disable=too-many-locals
+    def calc_in_given_out(
+        self,
+        out: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_in: TokenType,
+        fee_percent: float,
+        stretched_time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
+        r"""
+        Calculates the amount of an asset that must be provided to receive a
+        specified amount of the other asset given the current AMM reserves.
+
+        The input is calculated as:
+
+        .. math::
+            in' =
+            \begin{cases}
+            c (\frac{1}{\mu} (\frac{k - (2y + cz - \Delta y)^{1-t}}{\frac{c}{\mu}})^{\frac{1}{1-t}} - z),
+            &\text{ if } token\_in = \text{"base"} \\
+            (k - \frac{c}{\mu} (\mu * (z - \Delta z))^{1 - t})^{\frac{1}{1 - t}} - (2y + cz),
+            &\text{ if } token\_in = \text{"pt"}
+            \end{cases} \\
+            f =
+            \begin{cases}
+            (1 - \frac{1}{(\frac{2y + cz}{\mu z})^{\tau}}) \phi \Delta y, &\text{ if } token\_in = \text{"base"} \\
+            (\frac{2y + cz}{\mu z})^{\tau} - 1) \phi (c \Delta z), &\text{ if } token\_in = \text{"pt"}
+            \end{cases} \\
+            in = in' + f
+
+        Arguments
+        ---------
+        out : float
+            The amount of tokens that the user wants to receive. When the user
+            wants to pay in bonds, this value should be an amount of base tokens
+            rather than an amount of shares.
+        share_reserves : float
+            The reserves of shares in the pool.
+        bond_reserves : float
+            The reserves of bonds in the pool.
+        token_in : str
+            The token that the user pays. The only valid values are "base" and
+            "pt".
+        fee_percent : float
+            The percentage of the difference between the amount paid without
+            slippage and the amount received that will be added to the input
+            as a fee.
+        stretched_time_remaining : float
+            The time remaining for the asset (incorporates time stretch).
+        init_share_price : float
+            The share price when the pool was initialized.
+        share_price : float
+            The current share price.
+
+        Returns
+        -------
+        float
+            The amount the user pays without fees or slippage. The units
+            are always in terms of bonds or base.
+        float
+            The amount the user pays with fees and slippage. The units are
+            always in terms of bonds or base.
+        float
+            The amount the user pays with slippage and no fees. The units are
+            always in terms of bonds or base.
+        float
+            The fee the user pays. The units are always in terms of bonds or
+            base.
+        """
+        assert out > 0, f"pricing_models.calc_in_given_out: ERROR: expected out > 0, not {out}!"
+        assert (
+            share_reserves >= 0
+        ), f"pricing_models.calc_in_given_out: ERROR: expected share_reserves >= 0, not {share_reserves}!"
+        assert (
+            bond_reserves >= 0
+        ), f"pricing_models.calc_in_given_out: ERROR: expected bond_reserves >= 0, not {bond_reserves}!"
+        assert (
+            1 >= fee_percent >= 0
+        ), f"pricing_models.calc_in_given_out: ERROR: expected 1 >= fee_percent >= 0, not {fee_percent}!"
+        assert 1 > stretched_time_remaining >= 0, (
+            "pricing_models.calc_in_given_out: ERROR: expected 1 > "
+            + f"stretched_time_remaining >= 0, not {stretched_time_remaining}!"
+        )
+        assert share_price >= init_share_price >= 1, (
+            f"pricing_models.calc_in_given_out: ERROR:"
+            f" expected share_price >= init_share_price >= 1, not share_price={share_price}"
+            f" and init_share_price={init_share_price}!"
+        )
+        time_elapsed = 1 - stretched_time_remaining
+        scale = share_price / init_share_price
+        total_reserves = share_price * share_reserves + bond_reserves
+        spot_price = self.calc_spot_price_from_reserves(
+            share_reserves=share_reserves,
+            bond_reserves=bond_reserves,
+            init_share_price=init_share_price,
+            share_price=share_price,
+            time_remaining=stretched_time_remaining,
+        )
+        # We precompute the YieldSpace constant k using the current reserves and
+        # share price:
+        #
+        # k = (c / μ) * (μ * z)**(1 - t) + (2y + cz)**(1 - t)
+        k = price_utils.calc_k_const(share_reserves, bond_reserves, share_price, init_share_price, time_elapsed)
+        if token_in == "base":
+            in_reserves = share_reserves  # in is in units of shares
+            out_reserves = bond_reserves + total_reserves  # out is in units of pt, here we add virtual liquiqidity
+            d_bonds = out  # out is in units of pt
+            # The amount the user pays without fees or slippage is simply
+            # the amount of bonds the user would receive times the spot price of
+            # base in terms of bonds. If we let p be the conventional spot price,
+            # then we can write this as:
+            #
+            # without_fee_or_slippage = p * d_y
+            without_fee_or_slippage = spot_price * d_bonds
+            # We solve the YieldSpace invariant for the base paid for the
+            # requested amount of bonds. We set up the invariant where the user
+            # pays d_z' shares and receives d_y bonds:
+            #
+            # (c / μ) * (μ * (z + d_z'))**(1 - t) + (2y + cz - d_y)**(1 - t) = k
+            #
+            # Solving for d_z' gives us the amount of shares the user pays
+            # without including fees:
+            #
+            # d_z' = (1 / μ) * ((k - (2y + cz - d_y)**(1 - t)) / (c / μ))**(1 / (1 - t)) - z
+            #
+            # We really want to know the value of d_x', the amount of base the
+            # user pays. This is given by d_x' = c * d_z'.
+            #
+            # without_fee = d_x'
+            without_fee = (
+                (1 / init_share_price)
+                * pow(
+                    (k - pow(out_reserves - d_bonds, time_elapsed)) / scale,
+                    1 / time_elapsed,
+                )
+                - in_reserves
+            ) * share_price
+            # The fees are calculated as the difference between the bonds
+            # received and the base paid without slippage times the fee
+            # percentage. This can also be expressed as:
+            #
+            # fee = (1 - p) * φ * d_y
+            fee = (1 - spot_price) * fee_percent * d_bonds
+        elif token_in == "pt":
+            in_reserves = bond_reserves + total_reserves  # in is in units of pt, here we add virtual liquidity
+            out_reserves = share_reserves  # out is in units of base
+            d_shares = out / share_price  # out is in units of base, so we convert it to shares (x = c * z => z = x / c)
+            assert d_shares <= share_reserves, (
+                "pricing_models.calc_in_given_out: ERROR: expected d_shares <= share_reserves,"
+                + f"got {d_shares} > {share_reserves}!"
+            )
+            # The amount the user pays without fees or slippage is simply the
+            # amount of base the user would receive times the inverse of the
+            # spot price of base in terms of bonds. The amount of base the user
+            # receives is given by c * d_z where d_z is the number of shares the
+            # pool will need to unwrap to give the user their base. If we let p
+            # be the conventional spot price, then we can write this as:
+            #
+            # without_fee_or_slippage = (1 / p) * c * d_z
+            without_fee_or_slippage = (1 / spot_price) * share_price * d_shares
+            # We solve the YieldSpace invariant for the bonds paid to receive
+            # the requested amount of base. We set up the invariant where the
+            # user pays d_y' bonds and receives d_z shares:
+            #
+            # (c / μ) * (μ * (z - d_z))**(1 - t) + (2y + cz + d_y')**(1 - t) = k
+            #
+            # Solving for d_y' gives us the amount of bonds the user must pay
+            # without including fees:
+            #
+            # d_y' = (k - (c / μ) * (μ * (z - d_z))**(1 - t))**(1 / (1 - t)) - (2y + cz)
+            #
+            # without_fee = d_y'
+            without_fee = (
+                pow(
+                    k - scale * pow((init_share_price * (out_reserves - d_shares)), time_elapsed),
+                    1 / time_elapsed,
+                )
+                - in_reserves
+            )
+            # The fees are calculated as the difference between the bonds paid
+            # without slippage and the base received times the fee percentage.
+            # This can also be expressed as:
+            #
+            # fee = ((1 / p) - 1) * φ * c * d_z
+            logging.debug(
+                (
+                    "fee = ((1 / spot_price) - 1) * fee_percent * share_price * d_shares\n\t"
+                    "%g = ((1 / %g) - 1) * %g * %g * %g"
+                ),
+                spot_price,
+                fee_percent,
+                share_price,
+                d_shares,
+                ((1 / spot_price) - 1) * fee_percent * share_price * d_shares,
+            )
+            fee = ((1 / spot_price) - 1) * fee_percent * share_price * d_shares
+        else:
+            raise AssertionError(
+                "pricing_models.calc_in_given_out: ERROR: " f'expected token_in to be "base" or "pt", not {token_in}!'
+            )
+        # To get the amount paid with fees, add the fee to the calculation that
+        # excluded fees. Adding the fees results in more tokens paid, which
+        # indicates that the fees are working correctly.
+        with_fee = without_fee + fee
+        assert fee >= 0, (
+            "pricing_models.calc_in_given_out: ERROR: Fee should not be negative!"
+            f"\n\tout={out}\n\tshare_reserves={share_reserves}\n\tbond_reserves={bond_reserves}"
+            f"\n\ttotal_reserves={total_reserves}\n\tinit_share_price={init_share_price}"
+            f"\n\tshare_price={share_price}\n\tscale={scale}\n\tfee_percent={fee_percent}"
+            f"\n\tstretched_time_remaining={stretched_time_remaining}\n\ttime_elapsed={time_elapsed}"
+            f"\n\tin_reserves={in_reserves}\n\tout_reserves={out_reserves}\n\ttoken_in={token_in}"
+            f"\n\tspot_price={spot_price}\n\tk={k}\n\twithout_fee_or_slippage={without_fee_or_slippage}"
+            f"\n\twithout_fee={without_fee}\n\tfee={fee}"
+        )
+
+        # TODO(jalextowle): With some analysis, it seems possible to show that
+        # we skip straight from non-negative reals to the complex plane without
+        # hitting negative reals.
+        #
+        # Ensure that the outputs are all non-negative floats. We only need to
+        # check without_fee since without_fee_or_slippage will always be a positive
+        # float due to the constraints on the inputs, with_fee = without_fee + fee
+        # so it is a positive float if without_fee and fee are positive floats, and
+        # fee is a positive float due to the constraints on the inputs.
+        assert fee >= 0, (
+            f"pricing_models.calc_in_given_out: ERROR: Fee should not be negative!"
+            f"\n\tout={out}\n\tshare_reserves={share_reserves}\n\tbond_reserves={bond_reserves}"
+            f"\n\ttotal_reserves={total_reserves}\n\tinit_share_price={init_share_price}"
+            f"\n\tshare_price={share_price}\n\tscale={scale}\n\tfee_percent={fee_percent}"
+            f"\n\tstretched_time_remaining={stretched_time_remaining}\n\ttime_elapsed={time_elapsed}"
+            f"\n\tin_reserves={in_reserves}\n\tout_reserves={out_reserves}\n\ttoken_in={token_in}"
+            f"\n\tspot_price={spot_price}\n\tk={k}\n\twithout_fee_or_slippage={without_fee_or_slippage}"
+            f"\n\twithout_fee={without_fee}\n\tfee={fee}"
+        )
+        assert isinstance(without_fee, float), (
+            f"pricing_models.calc_in_given_out: ERROR: without_fee should be a float, not {type(without_fee)}!"
+            f"\n\tout={out}\n\tshare_reserves={share_reserves}\n\tbond_reserves={bond_reserves}"
+            f"\n\ttotal_reserves={total_reserves}\n\tinit_share_price={init_share_price}"
+            f"\n\tshare_price={share_price}\n\tscale={scale}\n\tfee_percent={fee_percent}"
+            f"\n\tstretched_time_remaining={stretched_time_remaining}\n\ttime_elapsed={time_elapsed}"
+            f"\n\tin_reserves={in_reserves}\n\tout_reserves={out_reserves}\n\ttoken_in={token_in}"
+            f"\n\tspot_price={spot_price}\n\tk={k}\n\twithout_fee_or_slippage={without_fee_or_slippage}"
+            f"\n\twithout_fee={without_fee}\n\tfee={fee}"
+        )
+        assert without_fee >= 0, (
+            f"pricing_models.calc_in_given_out: ERROR: without_fee should be non-negative, not {without_fee}!"
+            f"\n\tout={out}\n\tshare_reserves={share_reserves}\n\tbond_reserves={bond_reserves}"
+            f"\n\ttotal_reserves={total_reserves}\n\tinit_share_price={init_share_price}"
+            f"\n\tshare_price={share_price}\n\tscale={scale}\n\tfee_percent={fee_percent}"
+            f"\n\tstretched_time_remaining={stretched_time_remaining}\n\ttime_elapsed={time_elapsed}"
+            f"\n\tin_reserves={in_reserves}\n\tout_reserves={out_reserves}\n\ttoken_in={token_in}"
+            f"\n\tspot_price={spot_price}\n\tk={k}\n\twithout_fee_or_slippage={without_fee_or_slippage}"
+            f"\n\twithout_fee={without_fee}\n\tfee={fee}"
+        )
+
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)
+
+    # TODO: The high slippage tests in tests/test_pricing_model.py should
+    # arguably have much higher slippage. This is something we should
+    # consider more when thinking about the use of a time stretch parameter.
+    # TODO: Break this function up to use private class functions
+    # pylint: disable=too-many-locals
+    def calc_out_given_in(
+        self,
+        in_: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_out: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
+        r"""
+        Calculates the amount of an asset that must be provided to receive a
+        specified amount of the other asset given the current AMM reserves.
+
+        The output is calculated as:
+
+        .. math::
+            out' =
+            \begin{cases}
+            c (z - \frac{1}{\mu} (\frac{k - (2y + cz + \Delta y)^{1 - t}}{\frac{c}{\mu}})^{\frac{1}{1 - t}}),
+            &\text{ if } token\_out = \text{"base"} \\
+            2y + cz - (k - \frac{c}{\mu} (\mu (z + \Delta z))^{1 - t})^{\frac{1}{1 - t}},
+            &\text{ if } token\_out = \text{"pt"}
+            \end{cases} \\
+            f =
+            \begin{cases}
+            (1 - \frac{1}{(\frac{2y + cz}{\mu z})^{\tau}}) \phi \Delta y, &\text{ if } token\_out = \text{"base"} \\
+            (\frac{2y + cz}{\mu z})^{\tau} - 1) \phi (c \Delta z), &\text{ if } token\_out = \text{"pt"}
+            \end{cases} \\
+            out = out' + f
+
+        Arguments
+        ---------
+        in_ : float
+            The amount of tokens that the user pays. When users receive bonds,
+            this value reflects the base paid.
+        share_reserves : float
+            The reserves of shares in the pool.
+        bond_reserves : float
+            The reserves of bonds (PT) in the pool.
+        token_out : str
+            The token that the user receives. The only valid values are "base"
+            and "pt".
+        fee_percent : float
+            The percentage of the difference between the amount paid and the
+            amount received without slippage that will be debited from the
+            output as a fee.
+        time_remaining : float
+            The time remaining for the asset (incorporates time stretch).
+        init_share_price : float
+            The share price when the pool was initialized.
+        share_price : float
+            The current share price.
+
+        Returns
+        -------
+        float
+            The amount the user receives without fees or slippage. The units
+            are always in terms of bonds or base.
+        float
+            The amount the user receives with fees and slippage. The units are
+            always in terms of bonds or base.
+        float
+            The amount the user receives with slippage and no fees. The units are
+            always in terms of bonds or base.
+        float
+            The fee the user pays. The units are always in terms of bonds or
+            base.
+        """
+        assert in_ > 0, f"pricing_models.calc_out_given_in: ERROR: expected in_ > 0, not {in_}!"
+        assert (
+            share_reserves >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected share_reserves >= 0, not {share_reserves}!"
+        assert (
+            bond_reserves >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected bond_reserves >= 0, not {bond_reserves}!"
+        assert (
+            1 >= fee_percent >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected 1 >= fee_percent >= 0, not {fee_percent}!"
+        assert (
+            1 > time_remaining >= 0
+        ), f"pricing_models.calc_out_given_in: ERROR: expected 1 > time_remaining >= 0, not {time_remaining}!"
+        assert share_price >= init_share_price >= 1, (
+            "pricing_models.calc_out_given_in: ERROR: expected share_price >= init_share_price >= 1, not"
+            f" share_price={share_price} and init_share_price={init_share_price}!"
+        )
+
+        scale = share_price / init_share_price
+        time_elapsed = 1 - time_remaining
+        total_reserves = share_price * share_reserves + bond_reserves
+        spot_price = self.calc_spot_price_from_reserves(
+            share_reserves=share_reserves,
+            bond_reserves=bond_reserves,
+            init_share_price=init_share_price,
+            share_price=share_price,
+            time_remaining=time_remaining,
+        )
+        # We precompute the YieldSpace constant k using the current reserves and
+        # share price:
+        #
+        # k = (c / μ) * (μ * z)**(1 - t) + (2y + cz)**(1 - t)
+        k = price_utils.calc_k_const(share_reserves, bond_reserves, share_price, init_share_price, time_elapsed)
+        if token_out == "base":
+            d_bonds = in_
+            in_reserves = bond_reserves + total_reserves
+            out_reserves = share_reserves
+            # The amount the user would receive without fees or slippage is the
+            # amount of bonds the user pays times the spot price of base in
+            # terms of bonds. If we let p be the conventional spot price, then
+            # we can write this as:
+            #
+            # p * d_y
+            without_fee_or_slippage = spot_price * d_bonds
+            # We solve the YieldSpace invariant for the base received from
+            # selling the specified amount of bonds. We set up the invariant
+            # where the user pays d_y bonds and receives d_z' shares:
+            #
+            # (c / μ) * (μ * (z - d_z'))**(1 - t) + (2y + cz + d_y)**(1 - t) = k
+            #
+            # Solving for d_z' gives us the amount of shares the user receives
+            # without fees:
+            #
+            # d_z' = z - (1 / μ) * ((k - (2y + cz + d_y)**(1 - t)) / (c / μ))**(1 / (1 - t))
+            #
+            # We really want to know the value of d_x', the amount of base the
+            # user receives without fees. This is given by d_x' = c * d_z'.
+            #
+            # without_fee = d_x'
+            without_fee = (
+                share_reserves
+                - (1 / init_share_price) * ((k - (in_reserves + d_bonds) ** time_elapsed) / scale) ** (1 / time_elapsed)
+            ) * share_price
+            # The fees are calculated as the difference between the bonds paid
+            # and the base received without slippage times the fee percentage.
+            # This can also be expressed as:
+            #
+            # fee = (1 - p) * φ * d_y
+            fee = (1 - spot_price) * fee_percent * d_bonds
+        elif token_out == "pt":
+            d_shares = in_ / share_price  # convert from base_asset to z (x=cz)
+            in_reserves = share_reserves
+            out_reserves = bond_reserves + total_reserves
+            # The amount the user would receive without fees or slippage is
+            # the amount of base the user pays times inverse of the spot price
+            # of base in terms of bonds. If we let p be the conventional spot
+            # price, then we can write this as:
+            #
+            # (1 / p) * c * d_z
+            without_fee_or_slippage = (1 / spot_price) * share_price * d_shares
+            # We solve the YieldSpace invariant for the bonds received from
+            # paying the specified amount of base. We set up the invariant where
+            # the user pays d_z shares and receives d_y' bonds:
+            #
+            # (c / μ) * (μ * (z + d_z))**(1 - t) + (2y + cz - d_y')**(1 - t) = k
+            #
+            # Solving for d_y' gives us the amount of bonds the user receives
+            # without including fees:
+            #
+            # d_y' = 2y + cz - (k - (c / μ) * (μ * (z + d_z))**(1 - t))**(1 / (1 - t))
+            without_fee = out_reserves - pow(
+                k - scale * pow(init_share_price * (in_reserves + d_shares), time_elapsed), 1 / time_elapsed
+            )
+            # The fees are calculated as the difference between the bonds
+            # received without slippage and the base paid times the fee
+            # percentage. This can also be expressed as:
+            #
+            # ((1 / p) - 1) * φ * c * d_z
+            fee = ((1 / spot_price) - 1) * fee_percent * share_price * d_shares
+            logging.debug(
+                (
+                    "fee = ((1 / spot_price) - 1) * fee_percent * share_price * d_shares\n\t",
+                    "%g = ((1 / %g) - 1) * %g * %g * %g",
+                ),
+                fee,
+                spot_price,
+                fee_percent,
+                share_price,
+                d_shares,
+            )
+        else:
+            raise AssertionError(
+                f'pricing_models.calc_out_given_in: ERROR: expected token_out to be "base" or "pt", not {token_out}!'
+            )
+        # To get the amount paid with fees, subtract the fee from the
+        # calculation that excluded fees. Subtracting the fees results in less
+        # tokens received, which indicates that the fees are working correctly.
+        with_fee = without_fee - fee
+        # TODO(jalextowle): With some analysis, it seems possible to show that
+        # we skip straight from non-negative reals to the complex plane without
+        # hitting negative reals.
+        #
+        # Ensure that the outputs are all non-negative floats. We only need to
+        # check with_fee since without_fee_or_slippage will always be a positive
+        # float due to the constraints on the inputs, without_fee = with_fee + fee
+        # so it is a positive float if with_fee and fee are positive floats, and
+        # fee is a positive float due to the constraints on the inputs.
+        assert_bool = fee >= 0 and isinstance(with_fee, float) and with_fee >= 0
+        assert assert_bool, (
+            f"pricing_models.calc_out_given_in: ERROR: Fee & with_fee should be non-negative floats!"
+            f"\n\t{in_=}\n\t{share_reserves=}\n\t{bond_reserves=}"
+            f"\n\t{total_reserves=}\n\t{init_share_price=}"
+            f"\n\t{share_price=}\n\t{scale=}\n\t{fee_percent=}"
+            f"\n\t{time_remaining=}\n\t{time_elapsed=}"
+            f"\n\t{in_reserves=}\n\t{out_reserves=}\n\t{token_out=}"
+            f"\n\t{spot_price=}\n\t{k=}\n\t{without_fee_or_slippage=}"
+            f"\n\t{without_fee=}\n\t{type(without_fee)=}\n\t{fee=}\n\t{type(fee)=}"
+            f"\n\t{with_fee=}\n\t{type(with_fee)=}"
+        )
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)

--- a/src/elfpy/simulators.py
+++ b/src/elfpy/simulators.py
@@ -159,48 +159,175 @@ class Simulator:
         blocks_per_year = 365 * self.config.simulator.num_blocks_per_day
         return 1 / blocks_per_year
 
-    def collect_and_execute_trades(self, last_block_in_sim: bool = False) -> None:
-        """Get trades from the agent list, execute them, and update states
+    def override_variables(self, override_dict):
+        """Replace existing member & config variables with ones defined in override_dict"""
+        # override the config variables, including random variables that were set
+        for key, value in override_dict.items():
+            for config_obj in [self.config.market, self.config.amm, self.config.simulator]:
+                if hasattr(config_obj, key):  # TODO: This is not safe -- we should assign each key individually
+                    setattr(config_obj, key, value)
+                    if key == "vault_apy":  # support for float or list[float] types
+                        if isinstance(value, float):  # overwrite above setattr with the value replicated in a list
+                            self.config.simulator.vault_apy = [float(value)] * self.config.simulator.num_trading_days
+                        else:  # check that the length is correct; if so, then it is already set above
+                            assert len(value) == self.config.simulator.num_trading_days, (
+                                "vault_apy must have len equal to num_trading_days = "
+                                + f"{self.config.simulator.num_trading_days},"
+                                + f" not {len(value)}"
+                            )
+            if hasattr(self, key):
+                logging.info("Overriding %s from %s to %s.", key, str(getattr(self, key)), str(value))
+            else:
+                logging.info("Overriding %s from %s to %s.", key, "None", str(value))
+        # override the init_share_price if it is in the override_dict
+        if "init_share_price" in override_dict.keys():
+            self.init_share_price = override_dict["init_share_price"]  # \mu variable
+
+    def setup_init_lp_agent(self):
+        """
+        Calculate the required deposit amounts and instantiate the LP agent
 
         Arguments
         ---------
         last_block_in_sim : bool
             If True, indicates if the current set of trades are occuring on the final block in the simulation
         """
-        if not isinstance(self.market, Market):
-            raise ValueError("Market not defined")
-        # TODO: This is a HACK to prevent the initial LPer from rugging other agents.
-        # The initial LPer should be able to remove their liquidity and any open shorts can still be closed.
-        # But right now, if the LPer removes liquidity while shorts are open,
-        # then closing the shorts results in an error (share_reserves == 0).
-        if self.config.simulator.shuffle_users:
-            if last_block_in_sim:
-                wallet_ids = self.rng.permutation(  # shuffle wallets except init_lp
-                    [key for key in self.agents if key > 0]  # exclude init_lp before shuffling
-                )
-                wallet_ids = np.append(wallet_ids, 0)  # add init_lp so that they're always last
-            else:
-                wallet_ids = self.rng.permutation(list(self.agents))
-        for agent_id in wallet_ids:  # trade is different on the last block
-            agent = self.agents[agent_id]
-            if last_block_in_sim:  # get all of a agent's trades
-                trade_list = agent.get_liquidation_trades(self.market)
-            else:
-                trade_list = agent.get_trade_list(self.market, self.pricing_model)
-            for agent_trade in trade_list:  # execute trades
-                wallet_deltas = self.market.trade_and_update(agent_trade, self.pricing_model)
-                agent.update_wallet(
-                    wallet_deltas, self.market
-                )  # update agent state since market doesn't know about agents
-                logging.debug(
-                    "agent #%g wallet deltas = \n%s",
-                    agent.wallet_address,
-                    wallet_deltas.__dict__,
-                )
-                agent.log_status_report()
-                # TODO: Get simulator, market, pricing model, agent state strings and log
-                self.update_analysis_dict()
-                self.run_trade_number += 1
+        # get the reserve amounts for the target liquidity and pool APR
+        init_share_reserves, init_bond_reserves = price_utils.calc_liquidity(
+            target_liquidity=self.config.simulator.target_liquidity,
+            market_price=self.config.market.base_asset_price,
+            apr=self.config.simulator.init_pool_apy,
+            days_remaining=self.config.simulator.token_duration,
+            time_stretch=self.market.time_stretch_constant,
+            init_share_price=self.market.init_share_price,
+            share_price=self.market.init_share_price,
+        )[:2]
+        normalized_days_until_maturity = self.config.simulator.token_duration  # `t(d)`; full duration
+        stretch_time_remaining = time_utils.stretch_time(
+            normalized_days_until_maturity, self.market.time_stretch_constant
+        )  # tau(d)
+        # mock the short to assess what the delta market conditions will be
+        output_with_fee = self.market.pricing_model.calc_out_given_in(
+            in_=init_bond_reserves,
+            share_reserves=init_share_reserves,
+            bond_reserves=0,
+            token_out="pt",
+            fee_percent=self.config.simulator.fee_percent,
+            time_remaining=stretch_time_remaining,
+            init_share_price=self.market.init_share_price,
+            share_price=self.market.init_share_price,
+        )[1]
+        # output_with_fee will be subtracted from the share reserves, so we want to add that much extra in
+        base_to_lp = init_share_reserves + output_with_fee
+        # budget is the full amount for LP & short
+        budget = base_to_lp + init_bond_reserves
+        # construct the init_lp agent with desired budget, lp, and short amounts
+        init_lp_agent = import_module("elfpy.strategies.init_lp").Policy(
+            market=self.market,
+            rng=self.rng,
+            wallet_address=0,
+            budget=budget,
+            base_to_lp=base_to_lp,
+            pt_to_short=init_bond_reserves,
+        )
+        logging.info(
+            (
+                "Init LP agent #%03.0f statistics:\ntarget_apy = %g; target_liquidity = %g; "
+                "budget = %g; base_to_lp = %g; pt_to_short = %g"
+            ),
+            init_lp_agent.wallet_address,
+            self.config.simulator.init_pool_apy,
+            self.config.simulator.target_liquidity,
+            budget,
+            base_to_lp,
+            init_bond_reserves,
+        )
+        return init_lp_agent
+
+    def validate_custom_parameters(self, policy_instruction):
+        """
+        separate the policy name from the policy arguments and validate the arguments
+        """
+        policy_name, policy_args = policy_instruction.split(":")
+        try:
+            policy_args = policy_args.split(",")
+        except AttributeError as exception:
+            logging.info("ERROR: No policy arguments provided")
+            raise exception
+        try:
+            policy_args = [arg.split("=") for arg in policy_args]
+        except AttributeError as exception:
+            logging.info("ERROR: Policy arguments must be provided as key=value pairs")
+            raise exception
+        try:
+            kwargs = {key: float(value) for key, value in policy_args}
+        except ValueError as exception:
+            logging.info("ERROR: Policy arguments must be provided as key=value pairs")
+            raise exception
+        return policy_name, kwargs
+
+    def setup_simulated_entities(self, override_dict=None):
+        """
+        Constructs the agent list, pricing model, and market member variables
+
+        Arguments
+        ---------
+        override_dict : dict
+            Override member variables.
+            Keys in this dictionary must match member variables of the YieldSimulator class.
+
+        Returns
+        -------
+        There are no returns, but the function instantiates self.market and self.agents
+        """
+
+        assert (
+            self.random_variables_set
+        ), "ERROR: You must run simulator.set_random_variables() before constructing simulation entities"
+        if override_dict is not None:
+            self.override_variables(override_dict)  # apply the override dict
+        pricing_model = self._get_pricing_model(self.config.amm.pricing_model_name)  # construct pricing model object
+        # setup market
+        time_stretch_constant = pricing_model.calc_time_stretch(self.config.simulator.init_pool_apy)
+        self.market = Market(
+            fee_percent=self.config.simulator.fee_percent,  # g
+            token_duration=self.config.simulator.token_duration,
+            pricing_model=pricing_model,
+            time_stretch_constant=time_stretch_constant,
+            init_share_price=self.init_share_price,  # u from YieldSpace w/ Yield Baring Vaults
+            share_price=self.init_share_price,  # c from YieldSpace w/ Yield Baring Vaults
+        )
+        self.market.vault_apy = self.config.simulator.vault_apy[0]
+        # fill market pools
+        if self.config.simulator.init_lp:
+            init_lp_agent = self.setup_init_lp_agent()  # calculate lp amounts & instantiate lp agent
+            self.agents = {init_lp_agent.wallet_address: init_lp_agent}
+            # execute one special block just for the init_lp_agent
+            self.collect_and_execute_trades()
+        else:  # manual market configuration
+            self.agents = {}
+        self.market.log_market_step_string()
+        # continue adding other users
+        for policy_number, policy_instruction in enumerate(self.config.simulator.user_policies):
+            if ":" in policy_instruction:  # we have custom parameters
+                policy_name, kwargs = self.validate_custom_parameters(policy_instruction)
+            else:  # we don't havev custom parameters
+                policy_name = policy_instruction
+                kwargs = {}
+            logging.info(
+                "creating agent #%03.0f with policy %s and args %s",
+                policy_number + 1,
+                policy_name,
+                kwargs,
+            )
+            agent = import_module(f"elfpy.strategies.{policy_name}").Policy(
+                market=self.market,
+                rng=self.rng,
+                wallet_address=policy_number + 1,  # reserve agent 000 for init_lp, even if not used
+                **kwargs,
+            )
+            agent.log_status_report()
+            self.agents.update({agent.wallet_address: agent})
 
     def run_simulation(self) -> None:
         r"""
@@ -243,9 +370,53 @@ class Simulator:
         for agent in self.agents.values():
             agent.log_final_report(self.market, self.pricing_model)
 
-    def update_analysis_dict(self) -> None:
+    def collect_and_execute_trades(self, last_block_in_sim=False):
+        """Get trades from the agent list, execute them, and update states"""
+        if not isinstance(self.market, Market):
+            raise ValueError("market not defined")
+        number_of_executed_trades = 0
+        # TODO: This is a HACK to prevent the initial LPer from rugging other agents.
+        # The initial LPer should be able to remove their liquidity and any open shorts can still be closed.
+        # But right now, if the LPer removes liquidity while shorts are open,
+        # then closing the shorts results in an error (share_reserves == 0).
+        if self.config.simulator.shuffle_users:
+            if last_block_in_sim:
+                wallet_ids = self.rng.permutation(  # shuffle wallets except init_lp
+                    [key for key in self.agents if key > 0]  # exclude init_lp before shuffling
+                )
+                wallet_ids = np.append(wallet_ids, 0)  # add init_lp so that they're always last
+            else:  # include init_lp only on the last block, to let it unwind
+                wallet_ids = self.rng.permutation(list(self.agents))
+        else:  # we are in a deterministic mode
+            # reverse the list excluding 0 (init_lp)
+            wallet_ids = [key for key in self.agents if key > 0][::-1]
+            if self.config.simulator.init_lp and last_block_in_sim:  # prepend init_lp to the list
+                wallet_ids = np.append(wallet_ids, 0)
+        for agent_id in wallet_ids:  # trade is different on the last block
+            agent = self.agents[agent_id]
+            if last_block_in_sim:  # get all of a agent's trades
+                trade_list = agent.get_liquidation_trades()
+            else:
+                trade_list = agent.get_trade_list()
+            for agent_trade in trade_list:  # execute trades
+                wallet_deltas = self.market.trade_and_update(agent_trade)
+                agent.update_wallet(wallet_deltas)  # update agent state since market doesn't know about agents
+                logging.debug(
+                    "agent #%03.0f wallet deltas = \n%s",
+                    agent.wallet_address,
+                    wallet_deltas.__dict__,
+                )
+                agent.log_status_report()
+                self.update_analysis_dict()
+                self.run_trade_number += 1
+                number_of_executed_trades += 1
+        if number_of_executed_trades > 0:
+            logging.info("executed %f trades at %s", number_of_executed_trades, self.market.get_market_state_string())
+
+    def update_analysis_dict(self):
         """Increment the list for each key in the analysis_dict output variable"""
         # pylint: disable=too-many-statements
+
         if not isinstance(self.market, Market):
             raise ValueError("Market not defined")
         self.analysis_dict["model_name"].append(self.pricing_model.model_name())

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -86,18 +86,18 @@ class MarketAction:
     # wallet_address is always set automatically by the basic agent class
     wallet_address: int
     # mint time is set only for trades that act on existing positions (close long or close short)
-    mint_time: float = 0
+    mint_time: float = None
 
     def __str__(self):
         """Return a description of the Action"""
-        output_string = f"AGENT ACTION:\nagent #{self.wallet_address}"
+        output_string = f"AGENT ACTION:\nagent #{self.wallet_address:03.0f}"
         for key, value in self.__dict__.items():
             if key == "action_type":
                 output_string += f" execute {value}()"
             elif key in ["trade_amount", "mint_time"]:
-                output_string += f" {key}: {float_to_string(value)}"
+                output_string += f" {key}: {value}"
             elif key not in ["wallet_address", "agent"]:
-                output_string += f" {key}: {float_to_string(value)}"
+                output_string += f" {key}: {value}"
         return output_string
 
 
@@ -131,11 +131,11 @@ class MarketDeltas:
                 if value != 0:
                     output_string += f" {key}: "
                     if isinstance(value, float):
-                        output_string += f"{float_to_string(value)}"
+                        output_string += f"{value}"
                     elif isinstance(value, list):
-                        output_string += "[" + ", ".join([float_to_string(x) for x in value]) + "]"
+                        output_string += "[" + ", ".join([x for x in value]) + "]"
                     elif isinstance(value, dict):
-                        output_string += "{" + ", ".join([f"{k}: {float_to_string(v)}" for k, v in value.items()]) + "}"
+                        output_string += "{" + ", ".join([f"{k}: {v}" for k, v in value.items()]) + "}"
                     else:
                         output_string += f"{value}"
         return output_string

--- a/src/elfpy/utils/outputs.py
+++ b/src/elfpy/utils/outputs.py
@@ -71,11 +71,10 @@ def float_to_string(value, precision=3, min_digits=0, debug=False):
                 f" min_digits={min_digits}, \n error={err}"
             )
         return str(value)
-    # decimals = np.clip(precision - digits, 0, precision)
-    decimals = min(max(precision - digits, min_digits), precision)  #  calculate desired decimals
+    decimals = np.clip(precision - digits, min_digits, precision)  # sigfigs to the right of the decimal
     if debug:
         print(f"value: {value}, type: {type(value)} calculated digits: {digits}, decimals: {decimals}")
-    if abs(value) > 0.1:
+    if abs(value) > 0.01:
         string = f"{value:,.{decimals}f}"
     else:  # add an additional sigfig if the value is really small
         string = f"{value:0.{precision-1}e}"

--- a/src/elfpy/utils/price.py
+++ b/src/elfpy/utils/price.py
@@ -166,7 +166,7 @@ def calc_apr_from_spot_price(price: float, time_remaining: StretchedTime):
     float
         APR (decimal) calculated from the provided parameters
     """
-    assert price > 0, (
+    assert price >= 0, (
         "utils.price.calc_apr_from_spot_price: ERROR: "
         f"Price argument should be greater or equal to zero, not {price}"
     )

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -67,14 +67,14 @@ class Wallet:
         output_string = ""
         for key, value in vars(self).items():
             if value:  #  check if object exists
-                if value != 0:
+                if value != 0 and value is not None:
                     output_string += f" {key}: "
                     if isinstance(value, float):
-                        output_string += f"{float_to_string(value)}"
+                        output_string += f"{value}"
                     elif isinstance(value, list):
-                        output_string += "[" + ", ".join([float_to_string(x) for x in value]) + "]"
+                        output_string += "[" + ", ".join(list(value)) + "]"
                     elif isinstance(value, dict):
-                        output_string += "{" + ", ".join([f"{k}: {float_to_string(v)}" for k, v in value.items()]) + "}"
+                        output_string += "{" + ", ".join([f"{k}: {v}" for k, v in value.items()]) + "}"
                     else:
                         output_string += f"{value}"
         return output_string

--- a/tests/test_sequential.py
+++ b/tests/test_sequential.py
@@ -1,0 +1,42 @@
+# pylint: disable=duplicate-code
+"""
+basic simulation
+consists of only two agents: single_LP and single_short
+each only does their action once, then liquidates at the end
+this tests pool bootstrap behavior since it doesn't use init_LP to seed the pool
+"""
+
+import time
+import os
+
+from test_trade import BaseTradeTest
+
+from elfpy.utils.float_to_string import float_to_string
+
+if os.scandir("config"):
+    config_file = os.path.join(os.pardir, os.getcwd(), "config", "example_config.toml")
+else:
+    config_file = os.path.join(os.pardir, os.getcwd(), "example_config.toml")
+
+lp_base = BaseLPTest()
+
+# run a test
+override_dict = {
+    # "num_blocks_per_day": int(24 * 60 * 60 / 12),  # 12 second block time
+    # "verbose": True,
+    "pricing_model_name": "Hyperdrive",
+    "shuffle_users": False,
+    "init_LP": False,
+    "verbose": True,
+}
+
+start = time.time()
+lp_base.run_base_lp_test(
+    user_policies=["single_LP", "single_short"], config_file=config_file, additional_overrides=override_dict
+)
+dur = time.time() - start
+if dur > 1:
+    output_string = f"test took {float_to_string(dur*1000,precision=2)} milliseconds"
+else:
+    output_string = f"test took {float_to_string(dur,precision=2)} seconds"
+print(output_string)

--- a/tests/test_trade.py
+++ b/tests/test_trade.py
@@ -161,3 +161,63 @@ class SingleTradeTests(BaseTradeTest):
     def test_base_lps(self):
         """Tests base LP setups"""
         self.run_base_lp_test(agent_policies=["single_lp"], config_file="config/example_config.toml")
+
+    def run_custom_parameters_test(self, user_policies, agent_params_to_check):
+        """Test custom parameters passed to agent creation"""
+        simulator = self.run_base_trade_test(user_policies=user_policies, config_file="config/example_config.toml")
+        for agent, agent_param in enumerate(agent_params_to_check):
+            for key, value in agent_param.items():
+                np.testing.assert_almost_equal(
+                    getattr(simulator.agents[agent + 1], key),
+                    value,
+                    err_msg=f"{key} does not equal {value}",
+                )
+
+    def test_custom_parameters(self):
+        """Tests passing custom parameters"""
+        list_of_user_policies_that_pass = [["single_lp:base_to_lp=200", "single_short:pt_to_short=500"]]
+        list_of_user_policies_that_fail = [
+            ["single_lp:base_to_lp=200", "single_short:pt_to_short=499"],
+            ["single_lp:base_to_lp=200", "single_short:pt_to_short=501"],
+            ["single_lp:base_to_lp=199", "single_short:pt_to_short=500"],
+            ["single_lp:base_to_lp=201", "single_short:pt_to_short=500"],
+        ]
+        agent_params_to_check = (
+            {"base_to_lp": 200},  # agent 1
+            {"pt_to_short": 500},  # agent 2
+        )
+        for user_policies in list_of_user_policies_that_pass:
+            self.run_custom_parameters_test(user_policies, agent_params_to_check)
+        for user_policies in list_of_user_policies_that_fail:
+            with self.assertRaises(AssertionError):
+                self.run_custom_parameters_test(user_policies, agent_params_to_check)
+
+    def run_custom_parameters_test(self, user_policies, agent_params_to_check):
+        """Test custom parameters passed to agent creation"""
+        simulator = self.run_base_trade_test(user_policies=user_policies, config_file="config/example_config.toml")
+        for agent, agent_param in enumerate(agent_params_to_check):
+            for key, value in agent_param.items():
+                np.testing.assert_almost_equal(
+                    getattr(simulator.agents[agent + 1], key),
+                    value,
+                    err_msg=f"{key} does not equal {value}",
+                )
+
+    def test_custom_parameters(self):
+        """Tests passing custom parameters"""
+        list_of_user_policies_that_pass = [["single_lp:base_to_lp=200", "single_short:pt_to_short=500"]]
+        list_of_user_policies_that_fail = [
+            ["single_lp:base_to_lp=200", "single_short:pt_to_short=499"],
+            ["single_lp:base_to_lp=200", "single_short:pt_to_short=501"],
+            ["single_lp:base_to_lp=199", "single_short:pt_to_short=500"],
+            ["single_lp:base_to_lp=201", "single_short:pt_to_short=500"],
+        ]
+        agent_params_to_check = (
+            {"base_to_lp": 200},  # agent 1
+            {"pt_to_short": 500},  # agent 2
+        )
+        for user_policies in list_of_user_policies_that_pass:
+            self.run_custom_parameters_test(user_policies, agent_params_to_check)
+        for user_policies in list_of_user_policies_that_fail:
+            with self.assertRaises(AssertionError):
+                self.run_custom_parameters_test(user_policies, agent_params_to_check)

--- a/tests/utils/test_time_utils.py
+++ b/tests/utils/test_time_utils.py
@@ -23,10 +23,11 @@ class TestTimeUtils(unittest.TestCase):
 
         now = datetime.datetime.now(pytz.timezone("Etc/GMT-0"))
         test_time = time_utils.current_datetime()
+        time_delta = datetime.timedelta(milliseconds=100)
+        before = now - time_delta
+        after = now + time_delta
 
-        assert (
-            now < test_time < (now + datetime.timedelta(milliseconds=100))
-        ), f"Unexpected time value {test_time} should be close to {now}"
+        assert before < test_time < after, f"Unexpected time value {test_time} should be between {before} and {after}"
 
     def test_block_number_to_datetime(self):
         """Test the block_number_to_datetime function"""


### PR DESCRIPTION
**major changes**:
- fix get_max_pt_short
- print market_step only if executed trades
- pass kwargs to agents to allow arbitrary parameters passed in testing
- add testing to verify that custom parameters are working as intended
- make deleting log file optional with a parameter

**fixes**:
- fix bug that initialized mint_time to 0 instead of None which resulted in wrong time_remaining calculation
- fix close_short accounting not receiving sale proceeds
- revert previous incorrect attempts to fix max short
- add handler close statements to avoid file permission errors in windows

**minor changes**:
- remove float_to_string since it's not useful for logging (only for printing to terminal)
- remove fees_paid since it isn't needed
- remove effective_price since it's informative only, can be calculated post-sim
- rename time_remaining to stretched_time_remaining to clarify what should be passed in
- additional comments to clarify what units are being passed in
- rename amount_to_lp to base_to_lp
- few additional logging statements and clarifications