### PR TITLE
Add a bunch of type hints to Agent, Market, Pricing Models

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -17,6 +17,7 @@ from elfpy.wallet import Wallet
 AgentActionType = Literal["close_short", "close_long", "open_short", "open_long", "add_liquidity", "remove_liquidity"]
 TradeDirection = Literal["out", "in"]
 
+
 # TODO: The agent class has too many instance attributes (8/7)
 #     we should move some, like budget and wallet_address, into the agent wallet and out of User
 class Agent:
@@ -71,7 +72,9 @@ class Agent:
                     output_string += f" {key}: {float_to_string(value)}"
             print(output_string)
 
-    def create_agent_action(self, action_type: AgentActionType, trade_amount: float, mint_time: float=0) -> AgentAction:
+    def create_agent_action(
+        self, action_type: AgentActionType, trade_amount: float, mint_time: float = 0
+    ) -> AgentAction:
         """Instantiate a agent action"""
         agent_action = self.AgentAction(
             # these two variables are required to be set by the strategy

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -18,7 +18,7 @@ from elfpy.wallet import Wallet
 #     we should move some, like budget and wallet_address, into the agent wallet and out of User
 class Agent:
     """
-    Implements abstract classes that control user behavior
+    Implements abstract classes that control agent behavior
     user has a budget that is a dict, keyed with a date
     value is an inte with how many tokens they have for that date
     """
@@ -33,12 +33,13 @@ class Agent:
         """
         self.market = market
         self.rng = rng
+        # TODO: remove this, wallet_address is a property of wallet, not the agent
         self.wallet_address = wallet_address
         self.budget = budget
         self.verbose = verbose
         self.last_update_spend = 0
         self.product_of_time_and_base = 0
-        self.wallet = Wallet(base_in_wallet=budget)
+        self.wallet = Wallet(address=wallet_address, base_in_wallet=budget)
 
     @dataclass
     class AgentAction:

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -64,7 +64,7 @@ class AgentWallet:
 # TODO: The user class has too many instance attributes (8/7)
 #     we should move some, like budget and wallet_address, into the agent wallet and out of User
 # pylint: disable=too-many-instance-attributes
-class User:
+class Agent:
     """
     Implements abstract classes that control user behavior
     user has a budget that is a dict, keyed with a date

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -11,20 +11,15 @@ from elfpy.utils.outputs import float_to_string
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.wallet import Wallet
 
-
-# TODO: The agent class has too many instance attributes (8/7)
-#     we should move some, like budget and wallet_address, into the agent wallet and out of User
+# TODO: this will get fixed soon when verbose is removed due to better logging, revisit this lint
+# pylint: disable=too-many-instance-attributes
 class Agent:
     """
-    Implements abstract classes that control agent behavior
-    agent has a budget that is a dict, keyed with a date
-    value is an inte with how many tokens they have for that date
+    Implements a class that controls agent behavior agent has a budget that is a dict, keyed with a
+    date value is an inte with how many tokens they have for that date
     """
 
-    # TODO: variables assigned by child classes are referenced by User -- need to fix up agent inheritance
-    # pylint: disable=no-member
     # pylint: disable=too-many-arguments
-
     def __init__(self, market: Market, rng: Generator, wallet_address: int, budget: float, verbose: bool):
         """
         Set up initial conditions

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -5,65 +5,17 @@ TODO: rewrite all functions to have typed inputs
 """
 
 from dataclasses import dataclass
-from dataclasses import field
 from typing import Optional
 
 import numpy as np
 
 from elfpy.utils.outputs import float_to_string
 from elfpy.utils.bcolors import Bcolors as bcolors
-
-
-@dataclass(frozen=False)
-class AgentWallet:
-    """Stores what's in the agent's wallet"""
-
-    # TODO: Create our own dataclass decorator that is always mutable and includes dict set/get syntax
-    # pylint: disable=duplicate-code
-
-    # fungible
-    base_in_wallet: float
-    lp_in_wallet: float = 0  # they're fungible!
-    fees_paid: float = 0
-    # non-fungible (identified by mint_time, stored as dict)
-    token_in_wallet: dict = field(default_factory=dict)
-    base_in_protocol: dict = field(default_factory=dict)
-    token_in_protocol: dict = field(default_factory=dict)
-    effective_price: float = field(init=False)  # calculated after init, only for transactions
-
-    def __post_init__(self):
-        """Post initialization function"""
-        # check if this represents a trade (one side will be negative)
-        total_tokens = sum(list(self.token_in_wallet.values()))
-        if self.base_in_wallet < 0 or total_tokens < 0:
-            self.effective_price = total_tokens / self.base_in_wallet
-
-    def __getitem__(self, key):
-        return getattr(self, key)
-
-    def __setitem__(self, key, value):
-        setattr(self, key, value)
-
-    def __str__(self):
-        output_string = ""
-        for key, value in vars(self).items():
-            if value:  #  check if object exists
-                if value != 0:
-                    output_string += f" {key}: "
-                    if isinstance(value, float):
-                        output_string += f"{float_to_string(value)}"
-                    elif isinstance(value, list):
-                        output_string += "[" + ", ".join([float_to_string(x) for x in value]) + "]"
-                    elif isinstance(value, dict):
-                        output_string += "{" + ", ".join([f"{k}: {float_to_string(v)}" for k, v in value.items()]) + "}"
-                    else:
-                        output_string += f"{value}"
-        return output_string
+from elfpy.wallet import Wallet
 
 
 # TODO: The user class has too many instance attributes (8/7)
 #     we should move some, like budget and wallet_address, into the agent wallet and out of User
-# pylint: disable=too-many-instance-attributes
 class Agent:
     """
     Implements abstract classes that control user behavior
@@ -86,7 +38,7 @@ class Agent:
         self.verbose = verbose
         self.last_update_spend = 0
         self.product_of_time_and_base = 0
-        self.wallet = AgentWallet(base_in_wallet=budget)
+        self.wallet = Wallet(base_in_wallet=budget)
 
     @dataclass
     class AgentAction:

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -3,16 +3,19 @@ Implements abstract classes that control agent behavior
 """
 
 from dataclasses import dataclass
-from typing import Optional, Literal
+from typing import Literal
 
 import numpy as np
+from numpy.random._generator import Generator
+from elfpy.markets import Market
 
 from elfpy.utils.outputs import float_to_string
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.wallet import Wallet
 
 
-AGENT_ACTION_TYPE = Literal["close_short", "close_long", "open_short", "open_long", "add_liquidity", "remove_liquidity"]
+AgentActionType = Literal["close_short", "close_long", "open_short", "open_long", "add_liquidity", "remove_liquidity"]
+TradeDirection = Literal["out", "in"]
 
 # TODO: The agent class has too many instance attributes (8/7)
 #     we should move some, like budget and wallet_address, into the agent wallet and out of User
@@ -27,33 +30,36 @@ class Agent:
     # pylint: disable=no-member
     # pylint: disable=too-many-arguments
 
-    def __init__(self, market, rng, wallet_address, budget, verbose):
+    def __init__(self, market: Market, rng: Generator, wallet_address: int, budget: float, verbose: bool):
         """
         Set up initial conditions
         """
-        self.market = market
-        self.rng = rng
+        self.market: Market = market
+        self.rng: Generator = rng
         # TODO: remove this, wallet_address is a property of wallet, not the agent
-        self.wallet_address = wallet_address
-        self.budget = budget
-        self.verbose = verbose
-        self.last_update_spend = 0
-        self.product_of_time_and_base = 0
-        self.wallet = Wallet(address=wallet_address, base_in_wallet=budget)
+        self.wallet_address: int = wallet_address
+        self.budget: float = budget
+        self.verbose: bool = verbose
+        self.last_update_spend: float = 0  # timestamp
+        self.product_of_time_and_base: float = 0
+        self.wallet: Wallet = Wallet(address=wallet_address, base_in_wallet=budget)
 
+    # TODO: this is really a MarketAction.  should refactor this to live under the Market.
+    # Agent's don't need to know about markets, remove this coupling!
     @dataclass
     class AgentAction:
         """agent action specification"""
 
         # these two variables are required to be set by the strategy
-        action_type: str
+        action_type: AgentActionType
         trade_amount: float
         # wallet_address is always set automatically by the basic agent class
         wallet_address: int
-        # mint time is set only for trades that act on existing positions (close long or close short)
-        mint_time: Optional[float] = None
 
-        def print_description_string(self):
+        # mint time is set only for trades that act on existing positions (close long or close short)
+        mint_time: float = 0
+
+        def print_description_string(self) -> None:
             """Print a description of the Action"""
             output_string = f"{bcolors.FAIL}{self.wallet_address}{bcolors.ENDC}"
             for key, value in self.__dict__.items():
@@ -65,7 +71,7 @@ class Agent:
                     output_string += f" {key}: {float_to_string(value)}"
             print(output_string)
 
-    def create_agent_action(self, action_type: AGENT_ACTION_TYPE, trade_amount, mint_time=None):
+    def create_agent_action(self, action_type: AgentActionType, trade_amount: float, mint_time: float=0) -> AgentAction:
         """Instantiate a agent action"""
         agent_action = self.AgentAction(
             # these two variables are required to be set by the strategy
@@ -77,16 +83,16 @@ class Agent:
         )
         return agent_action
 
-    def action(self):
+    def action(self) -> list[AgentAction]:
         """Specify action from the policy"""
         raise NotImplementedError
 
-    def get_max_long(self):
+    def get_max_long(self) -> float:
         """Returns the amount of base that the agent can spend."""
         return np.minimum(self.wallet.base_in_wallet, self.market.bond_reserves)
 
     # TODO: Fix up this function
-    def get_max_pt_short(self):
+    def get_max_pt_short(self) -> float:
         """
         Returns an approximation of maximum amount of base that the agent can short given current market conditions
 
@@ -115,9 +121,6 @@ class Agent:
         for action in action_list:  # edit each action in place
             if action.mint_time is None:
                 action.mint_time = self.market.time
-            if action.action_type == "close_short":
-                action.token_in_protocol = self.wallet.token_in_protocol[action.mint_time]
-                action.base_in_protocol = self.wallet.base_in_protocol[action.mint_time]
         # TODO: Add safety checks
         # e.g. if trade amount > 0, whether there is enough money in the account
         # if len(trade_action) > 0: # there is a trade
@@ -128,17 +131,17 @@ class Agent:
         #    )
         return action_list
 
-    def update_spend(self):
+    def update_spend(self) -> None:
         """Track over time the agent's weighted average spend, for return calculation"""
         new_spend = (self.market.time - self.last_update_spend) * (self.budget - self.wallet["base_in_wallet"])
         self.product_of_time_and_base += new_spend
         self.last_update_spend = self.market.time
 
-    def update_wallet(self, wallet_deltas: Wallet):
+    def update_wallet(self, wallet_deltas: Wallet) -> None:
         """Update the agent's wallet"""
         self.update_spend()
-        for key, valueOrDict in wallet_deltas.__dict__.items():
-            if valueOrDict is None:
+        for key, value_or_dict in wallet_deltas.__dict__.items():
+            if value_or_dict is None:
                 pass
 
             # handle update value case
@@ -146,7 +149,7 @@ class Agent:
                 # TODO: add back in with high level of logging, category = "trade"
                 # if self.verbose and wallet != 0 or self.wallet[wallet_key] !=0:
                 #    print(f"   pre-trade {wallet_key:17s} = {self.wallet[wallet_key]:,.0f}")
-                self.wallet[key] += valueOrDict
+                self.wallet[key] += value_or_dict
                 # TODO: add back in with high level of logging, category = "trade"
                 # if self.verbose and wallet != 0 or self.wallet[wallet_key] !=0:
                 #    print(f"  post-trade {wallet_key:17s} = {self.wallet[wallet_key]:,.0f}")
@@ -155,7 +158,7 @@ class Agent:
             # handle updating a dict
             # these values have mint_time attached, stored as dicts
             elif key in ["base_in_protocol", "token_in_wallet", "token_in_protocol"]:
-                for mint_time, amount in valueOrDict.items():
+                for mint_time, amount in value_or_dict.items():
                     # TODO: add back in with high level of logging, category = "trade"
                     # if self.verbose:
                     #    print(f"   pre-trade {wallet_key:17s} = \
@@ -173,9 +176,9 @@ class Agent:
             else:
                 raise ValueError(f"wallet_key={key} is not allowed.")
 
-    def get_liquidation_trades(self):
+    def get_liquidation_trades(self) -> list[AgentAction]:
         """Get final trades for liquidating positions"""
-        action_list = []
+        action_list: list[Agent.AgentAction] = []
         for mint_time, position in self.wallet.token_in_protocol.items():
             if self.verbose:
                 print(
@@ -197,7 +200,8 @@ class Agent:
             )
         return action_list
 
-    def status_report(self):
+    # TODO: should be called get_status_report
+    def status_report(self) -> str:
         """Returns a status report for the agent"""
         output_string = f"{bcolors.FAIL}{self.wallet_address}{bcolors.ENDC} "
         string_list = []
@@ -207,7 +211,9 @@ class Agent:
         output_string += ", ".join(string_list)
         return output_string
 
-    def final_report(self):
+    # TODO: should be called print_final_report.  better yet, make get_final_report that returns a
+    # string, caller can print
+    def final_report(self) -> None:
         """Prints a report of the agent's state"""
         price = self.market.spot_price
         base = self.wallet.base_in_wallet

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -3,7 +3,7 @@ Implements abstract classes that control agent behavior
 """
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TypeAlias
 
 import numpy as np
 from numpy.random._generator import Generator
@@ -14,7 +14,9 @@ from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.wallet import Wallet
 
 
-AgentActionType = Literal["close_short", "close_long", "open_short", "open_long", "add_liquidity", "remove_liquidity"]
+AgentActionType: TypeAlias = Literal[
+    "close_short", "close_long", "open_short", "open_long", "add_liquidity", "remove_liquidity"
+]
 TradeDirection = Literal["out", "in"]
 
 

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -3,7 +3,7 @@ Implements abstract classes that control agent behavior
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Literal
 
 import numpy as np
 
@@ -11,6 +11,8 @@ from elfpy.utils.outputs import float_to_string
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.wallet import Wallet
 
+
+AGENT_ACTION_TYPE = Literal["close_short", "close_long", "open_short", "open_long", "add_liquidity", "remove_liquidity"]
 
 # TODO: The agent class has too many instance attributes (8/7)
 #     we should move some, like budget and wallet_address, into the agent wallet and out of User
@@ -63,7 +65,7 @@ class Agent:
                     output_string += f" {key}: {float_to_string(value)}"
             print(output_string)
 
-    def create_agent_action(self, action_type, trade_amount, mint_time=None):
+    def create_agent_action(self, action_type: AGENT_ACTION_TYPE, trade_amount, mint_time=None):
         """Instantiate a agent action"""
         agent_action = self.AgentAction(
             # these two variables are required to be set by the strategy

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -143,6 +143,8 @@ class Agent:
                     #       {{{' '.join([f'{k}: {v:,.0f}' for k, v in self.wallet[wallet_key].items()])}}}")
             elif key in ["fees_paid", "effective_price"]:
                 pass
+            elif key in ["address"]:
+                pass
             else:
                 raise ValueError(f"wallet_key={key} is not allowed.")
 

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 import elfpy.utils.time as time_utils
-from elfpy.agent import Wallet
+from elfpy.agent import AGENT_ACTION_TYPE, Wallet
 import elfpy.utils.price as price_utils
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.utils.outputs import float_to_string
@@ -125,11 +125,11 @@ class Market:
         self.total_supply = self.share_reserves + self.bond_reserves
         self.verbose = verbose
 
-    def check_action_type(self, action_type):
-        """Ensure that the user action is an allowed action for this market
+    def check_action_type(self, action_type: AGENT_ACTION_TYPE):
+        """Ensure that the agent action is an allowed action for this market
         Arguments
         ---------
-        action_type : str
+        action_type :
             must be either "element" or "hyperdrive"
         """
         pricing_model_name = self.pricing_model.model_name()
@@ -155,7 +155,7 @@ class Market:
                 f" model={self.pricing_model.model_name()}, not {action_type}!"
             )
 
-    def trade_and_update(self, agent_action):
+    def trade_and_update(self, agent_action: AGENT_ACTION_TYPE):
         """
         Execute a trade in the simulated market.
 

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -113,13 +113,13 @@ class Market:
 
     def __init__(
         self,
-        fee_percent: float,
-        token_duration: float,
+        fee_percent: float = 0,
+        token_duration: float = 1,
         # TODO: remove this, pass to methods instead
-        pricing_model: ElementPricingModel | HyperdrivePricingModel,
-        share_reserves: float,
-        bond_reserves: float,
-        lp_reserves: float,
+        pricing_model: ElementPricingModel | HyperdrivePricingModel | None = None,
+        share_reserves: float = 0,
+        bond_reserves: float = 0,
+        lp_reserves: float = 0,
         time_stretch_constant: float = 1,
         init_share_price: float = 1,
         share_price: float = 1,

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -197,17 +197,17 @@ class Market:
         # open/close_long/short functions so that this isn't necessary
         update_price_and_rate = True
         if agent_action.action_type == "open_long":  # buy to open long
-            market_deltas, agent_deltas = self._open_long(agent_action, "pt")
+            market_deltas, agent_deltas = self._open_long(agent_action, "pt", stretched_time_remaining)
         elif agent_action.action_type == "close_long":  # sell to close long
-            market_deltas, agent_deltas = self._close_long(agent_action, "base")
+            market_deltas, agent_deltas = self._close_long(agent_action, "base", stretched_time_remaining)
         elif agent_action.action_type == "open_short":  # sell PT to open short
-            market_deltas, agent_deltas = self._open_short(agent_action, "pt")
+            market_deltas, agent_deltas = self._open_short(agent_action, "pt", time_remaining)
         elif agent_action.action_type == "close_short":  # buy PT to close short
-            market_deltas, agent_deltas = self._close_short(agent_action, "pt")
+            market_deltas, agent_deltas = self._close_short(agent_action, "pt", stretched_time_remaining)
         elif agent_action.action_type == "add_liquidity":
-            market_deltas, agent_deltas = self._add_liquidity(agent_action)
+            market_deltas, agent_deltas = self._add_liquidity(agent_action, time_remaining, stretched_time_remaining)
         elif agent_action.action_type == "remove_liquidity":
-            market_deltas, agent_deltas = self._remove_liquidity(agent_action)
+            market_deltas, agent_deltas = self._remove_liquidity(agent_action, time_remaining, stretched_time_remaining)
             update_price_and_rate = False
         else:
             raise ValueError(f'ERROR: Unknown trade type "{agent_action.action_type}".')

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -2,6 +2,7 @@
 Market simulators store state information when interfacing AMM pricing models with users
 """
 
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal, TypeAlias
 
@@ -168,8 +169,7 @@ class Market:
         """Ensure that the agent action is an allowed action for this market
         Arguments
         ---------
-        action_type :
-            must be either "element" or "hyperdrive"
+        action_type: see MarketActionType for all acceptable actions that can be performed on this market
         """
         pricing_model_name = self.pricing_model.model_name()
         if pricing_model_name.lower() == "element":

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 import elfpy.utils.time as time_utils
-from elfpy.user import AgentWallet
+ import AgentWallet
 import elfpy.utils.price as price_utils
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.utils.outputs import float_to_string

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 import elfpy.utils.time as time_utils
- import AgentWallet
+from elfpy.agent import Wallet
 import elfpy.utils.price as price_utils
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.utils.outputs import float_to_string
@@ -386,7 +386,7 @@ class Market:
         )
         # TODO: _in_protocol values should be managed by pricing_model and referenced by user
         max_loss = trade_details.trade_amount - output_with_fee
-        wallet_deltas = AgentWallet(
+        wallet_deltas = Wallet(
             base_in_wallet=-max_loss,
             base_in_protocol={trade_details.mint_time: +max_loss},
             token_in_protocol={trade_details.mint_time: -trade_details.trade_amount},
@@ -437,7 +437,7 @@ class Market:
         # If the user is not closing a full short (i.e. the mint_time balance is not zeroed out)
         # then the user does not get any money into their wallet
         # Right now the user has to close the full short
-        agent_deltas = AgentWallet(
+        agent_deltas = Wallet(
             base_in_wallet=+output_with_fee,
             base_in_protocol={trade_details.mint_time: -output_with_fee},
             token_in_protocol={trade_details.mint_time: +trade_details.trade_amount},
@@ -478,14 +478,14 @@ class Market:
                 d_token_asset_orders=+1,
                 d_token_asset_volume=+output_with_fee,
             )
-            agent_deltas = AgentWallet(
+            agent_deltas = Wallet(
                 base_in_wallet=-trade_details.trade_amount,
                 token_in_protocol={trade_details.mint_time: +output_with_fee},
                 fees_paid=+fee,
             )
         else:
             market_deltas = MarketDeltas()
-            agent_deltas = AgentWallet(base_in_wallet=0)
+            agent_deltas = Wallet(base_in_wallet=0)
         return market_deltas, agent_deltas
 
     def _close_long(self, trade_details):
@@ -520,7 +520,7 @@ class Market:
             d_base_asset_orders=+1,
             d_base_asset_volume=+output_with_fee,
         )
-        agent_deltas = AgentWallet(
+        agent_deltas = Wallet(
             base_in_wallet=+output_with_fee,
             token_in_wallet={trade_details.mint_time: -trade_details.trade_amount},
             fees_paid=+fee,
@@ -553,7 +553,7 @@ class Market:
                 +trade_details.trade_amount,
             ],
         )
-        agent_deltas = AgentWallet(
+        agent_deltas = Wallet(
             base_in_wallet=-d_base_reserves,
             lp_in_wallet=+lp_out,
         )
@@ -585,7 +585,7 @@ class Market:
                 -trade_details.trade_amount,
             ],
         )
-        agent_deltas = AgentWallet(
+        agent_deltas = Wallet(
             base_in_wallet=+d_base_reserves,
             lp_in_wallet=-lp_in,
         )

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -1,18 +1,18 @@
 """
 Market simulators store state information when interfacing AMM pricing models with users
-
-TODO: rewrite all functions to have typed inputs
 """
 
 from dataclasses import dataclass, field
 
 import numpy as np
+from elfpy.pricing_models import ElementPricingModel, HyperdrivePricingModel, TradeResult
 
 import elfpy.utils.time as time_utils
-from elfpy.agent import AGENT_ACTION_TYPE, Wallet
+from elfpy.agent import Agent, AgentActionType, TokenType, TradeDirection
 import elfpy.utils.price as price_utils
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.utils.outputs import float_to_string
+from elfpy.wallet import Wallet
 
 # Currently many functions use >5 arguments.
 # These should be packaged up into shared variables, e.g.
@@ -34,13 +34,13 @@ class MarketDeltas:
     d_share_buffer: float = 0
     d_bond_buffer: float = 0
     d_lp_reserves: float = 0
-    d_lp_reserves_history: list = field(default_factory=list)
+    d_lp_reserves_history: list[float] = field(default_factory=list)
     d_base_asset_slippage: float = 0
     d_token_asset_slippage: float = 0
     d_share_fee: float = 0
-    d_share_fee_history: dict = field(default_factory=dict)
+    d_share_fee_history: dict[float, float] = field(default_factory=dict)
     d_token_fee: float = 0
-    d_token_fee_history: dict = field(default_factory=dict)
+    d_token_fee_history: dict[float, float] = field(default_factory=dict)
     d_base_asset_orders: int = 0
     d_token_asset_orders: int = 0
     d_base_asset_volume: float = 0
@@ -82,50 +82,58 @@ class Market:
 
     def __init__(
         self,
-        fee_percent,
-        token_duration,
-        pricing_model,
-        share_reserves=0,
-        bond_reserves=0,
-        lp_reserves=0,
-        time_stretch_constant=1,
-        init_share_price=1,
-        share_price=1,
-        verbose=False,
+        fee_percent: float,
+        token_duration: float,
+        # TODO: remove this, pass to methods instead
+        pricing_model: ElementPricingModel | HyperdrivePricingModel,
+        share_reserves: float,
+        bond_reserves: float,
+        lp_reserves: float,
+        time_stretch_constant: float = 1,
+        init_share_price: float = 1,
+        share_price: float = 1,
+        verbose: bool = False,
     ):
-        self.time = 0  # time in year fractions
-        self.share_reserves = share_reserves  # z
-        self.bond_reserves = bond_reserves  # y
-        self.share_buffer = 0
-        self.bond_buffer = 0
-        self.lp_reserves = lp_reserves
-        self.lp_reserves_history = []  # list trades by user and time, initialize as empty list to allow appending
-        self.fee_percent = fee_percent  # g
-        self.time_stretch_constant = time_stretch_constant
-        self.init_share_price = init_share_price  # u normalizing constant
-        self.share_price = share_price  # c
-        self.token_duration = token_duration  # how long does a token last before expiry
-        self.pricing_model = pricing_model
+        self.time: float = 0  # time normalized to 1 year, i.e. 0.5 = 1/2 year
+        self.share_reserves: float = share_reserves  # z
+        self.bond_reserves: float = bond_reserves  # y
+        self.share_buffer: float = 0
+        self.bond_buffer: float = 0
+        self.lp_reserves: float = lp_reserves
+        # TODO: why is this a list when other histories are a dict?  we should make this one match the
+        # others. honestly we should make history dict type if this is a common pattern
+        self.lp_reserves_history: list[
+            float
+        ] = []  # list trades by user and time, initialize as empty list to allow appending
+        self.fee_percent: float = fee_percent  # g
+        self.time_stretch_constant: float = time_stretch_constant
+        self.init_share_price: float = init_share_price  # u normalizing constant
+        self.share_price: float = share_price  # c
+        self.token_duration: float = token_duration  # how long does a token last before expiry
+
         # TODO: It would be good to remove the tight coupling between pricing models and markets.
         #       For now, it makes sense to restrict the behavior at the market level since
         #       previous versions of Element didn't allow for shorting (despite the fact that
         #       their pricing models can support shorting).
-        self.base_asset_orders = 0
-        self.token_asset_orders = 0
-        self.base_asset_volume = 0
-        self.token_asset_volume = 0
-        self.cum_token_asset_slippage = 0
-        self.cum_base_asset_slippage = 0
-        self.share_fees = 0
-        self.share_fee_history = {}
-        self.token_fees = 0
-        self.token_fee_history = {}
-        self.spot_price = 0
-        self.rate = 0
-        self.total_supply = self.share_reserves + self.bond_reserves
-        self.verbose = verbose
+        self.pricing_model: ElementPricingModel | HyperdrivePricingModel = pricing_model
 
-    def check_action_type(self, action_type: AGENT_ACTION_TYPE):
+        self.base_asset_orders: int = 0
+        self.token_asset_orders: int = 0
+        self.base_asset_volume: float = 0
+        self.token_asset_volume: float = 0
+        self.cum_token_asset_slippage: float = 0
+        self.cum_base_asset_slippage: float = 0
+        self.share_fees: float = 0
+        self.share_fee_history: dict[float, float] = {}
+        self.token_fees: float = 0
+        self.token_fee_history: dict[float, float] = {}
+        self.spot_price: float = 0
+        self.rate: float = 0
+        # TODO: fix this? is this true? total_supply is usually the num of lp shares, which is not equal to this sum
+        self.total_supply: float = self.share_reserves + self.bond_reserves
+        self.verbose: bool = verbose
+
+    def check_action_type(self, action_type: AgentActionType) -> None:
         """Ensure that the agent action is an allowed action for this market
         Arguments
         ---------
@@ -149,13 +157,13 @@ class Market:
                 "market.check_action_type: ERROR: pricing model name should "
                 f'be in ["element", "hyperdrive"], not {pricing_model_name}'
             )
-        if not action_type in allowed_actions:
+        if action_type not in allowed_actions:
             raise AssertionError(
                 "markets.check_action_type: ERROR: agent_action.action_type should be an allowed action for the"
                 f" model={self.pricing_model.model_name()}, not {action_type}!"
             )
 
-    def trade_and_update(self, agent_action: AGENT_ACTION_TYPE):
+    def trade_and_update(self, agent_action: Agent.AgentAction) -> Wallet:
         """
         Execute a trade in the simulated market.
 
@@ -176,34 +184,25 @@ class Market:
             LP tokens are also stored in user wallet as fungible amounts, for ease of use
         """
         self.check_action_type(agent_action.action_type)
+
         # TODO: check the desired amount is feasible, otherwise return descriptive error
         # update market variables which may have changed since the user action was created
-        agent_action.time_remaining = time_utils.get_yearfrac_remaining(
-            self.time, agent_action.mint_time, self.token_duration
-        )
-        agent_action.stretched_time_remaining = time_utils.stretch_time(
-            agent_action.time_remaining, self.time_stretch_constant
-        )
+        time_remaining = time_utils.get_yearfrac_remaining(self.time, agent_action.mint_time, self.token_duration)
+        stretched_time_remaining = time_utils.stretch_time(time_remaining, self.time_stretch_constant)
         # if self.verbose:
         agent_action.print_description_string()
         # for each position, specify how to forumulate trade and then execute
+        # TODO: we shouldn't set values on the object passed in, add parameters to
+        # open/close_long/short functions so that this isn't necessary
         update_price_and_rate = True
         if agent_action.action_type == "open_long":  # buy to open long
-            agent_action.direction = "out"  # calcOutGivenIn
-            agent_action.token_out = "pt"  # sell known base for unknown PT
-            market_deltas, agent_deltas = self._open_long(agent_action)
+            market_deltas, agent_deltas = self._open_long(agent_action, "pt")
         elif agent_action.action_type == "close_long":  # sell to close long
-            agent_action.direction = "out"  # calcOutGivenIn
-            agent_action.token_out = "base"  # sell known PT for unknown base
-            market_deltas, agent_deltas = self._close_long(agent_action)
+            market_deltas, agent_deltas = self._close_long(agent_action, "base")
         elif agent_action.action_type == "open_short":  # sell PT to open short
-            agent_action.direction = "in"  # calcOutGivenIn
-            agent_action.token_out = "pt"  # sell known PT for unknown base
-            market_deltas, agent_deltas = self._open_short(agent_action)
+            market_deltas, agent_deltas = self._open_short(agent_action, "pt")
         elif agent_action.action_type == "close_short":  # buy PT to close short
-            agent_action.direction = "in"  # calcOutGivenIn
-            agent_action.token_in = "pt"  # buy known PT for unknown base
-            market_deltas, agent_deltas = self._close_short(agent_action)
+            market_deltas, agent_deltas = self._close_short(agent_action, "pt")
         elif agent_action.action_type == "add_liquidity":
             market_deltas, agent_deltas = self._add_liquidity(agent_action)
         elif agent_action.action_type == "remove_liquidity":
@@ -217,11 +216,11 @@ class Market:
             print(f"market Δs ={market_deltas}")
         return agent_deltas
 
-    def update_market(self, market_deltas, update_price_and_rate=True):
+    def update_market(self, market_deltas: MarketDeltas, update_price_and_rate=True) -> None:
         """
         Increments member variables to reflect current market conditions
         """
-        # TODO: The nexted branching inside for-loops is cumbersome and can slow down the execution
+        # TODO: The nested branching inside for-loops is cumbersome and can slow down the execution
         # pylint: disable=too-many-branches
         for key, value in market_deltas.__dict__.items():
             if value:  # check that it's instantiated and non-empty
@@ -241,7 +240,7 @@ class Market:
         self.bond_buffer += market_deltas.d_bond_buffer
         self.lp_reserves += market_deltas.d_lp_reserves
         if market_deltas.d_lp_reserves_history:  # not empty
-            self.lp_reserves_history.append(market_deltas.d_lp_reserves_history)
+            self.lp_reserves_history.extend(market_deltas.d_lp_reserves_history)
         self.share_fees += market_deltas.d_share_fee
         if market_deltas.d_share_fee_history:  # not empty
             for key, value in market_deltas.d_share_fee_history.items():
@@ -272,13 +271,13 @@ class Market:
             )
             self.rate = price_utils.calc_apr_from_spot_price(self.spot_price, self.token_duration)
 
-    def get_market_state_string(self):
+    def get_market_state_string(self) -> str:
         """Returns a formatted string containing all of the Market class member variables"""
         strings = [f"{attribute} = {value}" for attribute, value in self.__dict__.items()]
         state_string = "\n".join(strings)
         return state_string
 
-    def get_target_reserves(self, token_in, trade_direction):
+    def get_target_reserves(self, token_in: TokenType, trade_direction: TradeDirection) -> float:
         """
         Determine which asset is the target based on token_in and trade_direction
         """
@@ -308,11 +307,11 @@ class Market:
 
     def check_fees(
         self,
-        amount,
-        tokens,
-        reserves,
-        trade_results,
-    ):
+        amount: float,
+        tokens: tuple[TokenType, TokenType],
+        reserves: tuple[float, float],
+        trade_results: TradeResult,
+    ) -> None:
         """Checks fee values for out of bounds and prints verbose outputs"""
         (token_in, token_out) = tokens
         (in_reserves, out_reserves) = reserves
@@ -346,23 +345,25 @@ class Market:
                 + state_string
             )
 
-    def tick(self, delta_time):
+    def tick(self, delta_time: float) -> None:
         """Increments the time member variable"""
         self.time += delta_time
 
-    def _open_short(self, trade_details):
+    def _open_short(
+        self, agent_action: Agent.AgentAction, token_out: TokenType, time_remaining: float
+    ) -> tuple[MarketDeltas, Wallet]:
         """
         take trade spec & turn it into trade details
         compute wallet update spec with specific details
         will be conditional on the pricing model
         """
         trade_results = self.pricing_model.calc_out_given_in(
-            in_=trade_details.trade_amount,
+            in_=agent_action.trade_amount,
             share_reserves=self.share_reserves,
             bond_reserves=self.bond_reserves,
-            token_out=trade_details.token_out,
+            token_out=token_out,
             fee_percent=self.fee_percent,
-            time_remaining=trade_details.stretched_time_remaining,
+            time_remaining=time_remaining,
             init_share_price=self.init_share_price,
             share_price=self.share_price,
         )
@@ -376,44 +377,47 @@ class Market:
             print(f"opening short: {without_fee_or_slippage, output_with_fee, output_without_fee, fee}")
         market_deltas = MarketDeltas(
             d_base_asset=-output_with_fee,
-            d_token_asset=+trade_details.trade_amount,
-            d_bond_buffer=+trade_details.trade_amount,
+            d_token_asset=+agent_action.trade_amount,
+            d_bond_buffer=+agent_action.trade_amount,
             d_share_fee=+fee / self.share_price,
-            d_share_fee_history={trade_details.mint_time: fee / self.share_price},
+            d_share_fee_history={agent_action.mint_time: fee / self.share_price},
             d_base_asset_slippage=+abs(without_fee_or_slippage - output_without_fee),
             d_base_asset_orders=+1,
             d_base_asset_volume=+output_with_fee,
         )
         # TODO: _in_protocol values should be managed by pricing_model and referenced by user
-        max_loss = trade_details.trade_amount - output_with_fee
+        max_loss = agent_action.trade_amount - output_with_fee
         wallet_deltas = Wallet(
+            address=0,
             base_in_wallet=-max_loss,
-            base_in_protocol={trade_details.mint_time: +max_loss},
-            token_in_protocol={trade_details.mint_time: -trade_details.trade_amount},
+            base_in_protocol={agent_action.mint_time: +max_loss},
+            token_in_protocol={agent_action.mint_time: -agent_action.trade_amount},
             fees_paid=+fee,
         )
         return market_deltas, wallet_deltas
 
-    def _close_short(self, trade_details):
+    def _close_short(
+        self, agent_action: Agent.AgentAction, token_in: TokenType, stretched_time_remaining: float
+    ) -> tuple[MarketDeltas, Wallet]:
         """
         take trade spec & turn it into trade details
         compute wallet update spec with specific details
             will be conditional on the pricing model
         """
-        if trade_details.trade_amount > self.bond_reserves:
+        if agent_action.trade_amount > self.bond_reserves:
             print(
-                f"markets._close_short: WARNING: trade amount = {trade_details.trade_amount} "
+                f"markets._close_short: WARNING: trade amount = {agent_action.trade_amount} "
                 f"is greater than bond reserves = {self.bond_reserves}."
                 f"Adjusting to allowable amount."
             )
-            trade_details.trade_amount = self.bond_reserves
+            agent_action.trade_amount = self.bond_reserves
         trade_results = self.pricing_model.calc_in_given_out(
-            trade_details.trade_amount,
+            agent_action.trade_amount,
             self.share_reserves,
             self.bond_reserves,
-            trade_details.token_in,
+            token_in,
             self.fee_percent,
-            trade_details.stretched_time_remaining,
+            stretched_time_remaining,
             self.init_share_price,
             self.share_price,
         )
@@ -425,10 +429,10 @@ class Market:
         ) = trade_results
         market_deltas = MarketDeltas(
             d_base_asset=+output_with_fee,
-            d_token_asset=-trade_details.trade_amount,
-            d_bond_buffer=-trade_details.trade_amount,
+            d_token_asset=-agent_action.trade_amount,
+            d_bond_buffer=-agent_action.trade_amount,
             d_share_fee=+fee / self.share_price,
-            d_share_fee_history={trade_details.mint_time: fee / self.share_price},
+            d_share_fee_history={agent_action.mint_time: fee / self.share_price},
             d_base_asset_slippage=+abs(without_fee_or_slippage - output_without_fee),
             d_base_asset_orders=+1,
             d_base_asset_volume=+output_with_fee,
@@ -438,27 +442,30 @@ class Market:
         # then the user does not get any money into their wallet
         # Right now the user has to close the full short
         agent_deltas = Wallet(
+            address=0,
             base_in_wallet=+output_with_fee,
-            base_in_protocol={trade_details.mint_time: -output_with_fee},
-            token_in_protocol={trade_details.mint_time: +trade_details.trade_amount},
+            base_in_protocol={agent_action.mint_time: -output_with_fee},
+            token_in_protocol={agent_action.mint_time: +agent_action.trade_amount},
             fees_paid=+fee,
         )
         return market_deltas, agent_deltas
 
-    def _open_long(self, trade_details):
+    def _open_long(
+        self, agent_action: Agent.AgentAction, token_out: TokenType, stretched_time_remaining: float
+    ) -> tuple[MarketDeltas, Wallet]:
         """
         take trade spec & turn it into trade details
         compute wallet update spec with specific details
             will be conditional on the pricing model
         """
-        if trade_details.trade_amount <= self.bond_reserves:
+        if agent_action.trade_amount <= self.bond_reserves:
             trade_results = self.pricing_model.calc_out_given_in(
-                trade_details.trade_amount,
+                agent_action.trade_amount,
                 self.share_reserves,
                 self.bond_reserves,
-                trade_details.token_out,
+                token_out,
                 self.fee_percent,
-                trade_details.stretched_time_remaining,
+                stretched_time_remaining,
                 self.init_share_price,
                 self.share_price,
             )
@@ -469,38 +476,41 @@ class Market:
                 fee,
             ) = trade_results
             market_deltas = MarketDeltas(
-                d_base_asset=+trade_details.trade_amount,
+                d_base_asset=+agent_action.trade_amount,
                 d_token_asset=-output_with_fee,
                 d_share_buffer=+output_with_fee / self.share_price,
                 d_token_fee=+fee,
-                d_token_fee_history={trade_details.mint_time: fee},
+                d_token_fee_history={agent_action.mint_time: fee},
                 d_token_asset_slippage=+abs(without_fee_or_slippage - output_without_fee),
                 d_token_asset_orders=+1,
                 d_token_asset_volume=+output_with_fee,
             )
             agent_deltas = Wallet(
-                base_in_wallet=-trade_details.trade_amount,
-                token_in_protocol={trade_details.mint_time: +output_with_fee},
+                address=0,
+                base_in_wallet=-agent_action.trade_amount,
+                token_in_protocol={agent_action.mint_time: +output_with_fee},
                 fees_paid=+fee,
             )
         else:
             market_deltas = MarketDeltas()
-            agent_deltas = Wallet(base_in_wallet=0)
+            agent_deltas = Wallet(address=0, base_in_wallet=0)
         return market_deltas, agent_deltas
 
-    def _close_long(self, trade_details):
+    def _close_long(
+        self, agent_action: Agent.AgentAction, token_out: TokenType, stretched_time_remaining: float
+    ) -> tuple[MarketDeltas, Wallet]:
         """
         take trade spec & turn it into trade details
         compute wallet update spec with specific details
             will be conditional on the pricing model
         """
         trade_results = self.pricing_model.calc_out_given_in(
-            trade_details.trade_amount,
+            agent_action.trade_amount,
             self.share_reserves,
             self.bond_reserves,
-            trade_details.token_out,
+            token_out,
             self.fee_percent,
-            trade_details.stretched_time_remaining,
+            stretched_time_remaining,
             self.init_share_price,
             self.share_price,
         )
@@ -512,27 +522,30 @@ class Market:
         ) = trade_results
         market_deltas = MarketDeltas(
             d_base_asset=-output_with_fee,
-            d_token_asset=+trade_details.trade_amount,
-            d_share_buffer=-trade_details.trade_amount / self.share_price,
+            d_token_asset=+agent_action.trade_amount,
+            d_share_buffer=-agent_action.trade_amount / self.share_price,
             d_share_fee=+fee / self.share_price,
-            d_share_fee_history={trade_details.mint_time: fee / self.share_price},
+            d_share_fee_history={agent_action.mint_time: fee / self.share_price},
             d_base_asset_slippage=+abs(without_fee_or_slippage - output_without_fee),
             d_base_asset_orders=+1,
             d_base_asset_volume=+output_with_fee,
         )
         agent_deltas = Wallet(
+            address=0,
             base_in_wallet=+output_with_fee,
-            token_in_wallet={trade_details.mint_time: -trade_details.trade_amount},
+            token_in_wallet={agent_action.mint_time: -agent_action.trade_amount},
             fees_paid=+fee,
         )
         return market_deltas, agent_deltas
 
-    def _add_liquidity(self, trade_details):
+    def _add_liquidity(
+        self, agent_action: Agent.AgentAction, time_remaining: float, stretched_time_remaining: float
+    ) -> tuple[MarketDeltas, Wallet]:
         """
         Computes new deltas for bond & share reserves after liquidity is added
         """
         lp_out, d_base_reserves, d_token_reserves = self.pricing_model.calc_lp_out_given_tokens_in(
-            d_base=trade_details.trade_amount,
+            d_base=agent_action.trade_amount,
             share_reserves=self.share_reserves,
             bond_reserves=self.bond_reserves,
             share_buffer=self.share_buffer,
@@ -540,31 +553,34 @@ class Market:
             share_price=self.share_price,
             lp_reserves=self.lp_reserves,
             rate=self.rate,
-            time_remaining=trade_details.time_remaining,
-            stretched_time_remaining=trade_details.stretched_time_remaining,
+            time_remaining=time_remaining,
+            stretched_time_remaining=stretched_time_remaining,
         )
         market_deltas = MarketDeltas(
             d_base_asset=+d_base_reserves,
             d_token_asset=+d_token_reserves,
             d_lp_reserves=+lp_out,
             d_lp_reserves_history=[
-                trade_details.mint_time,
-                trade_details.wallet_address,
-                +trade_details.trade_amount,
+                agent_action.mint_time,
+                agent_action.wallet_address,
+                +agent_action.trade_amount,
             ],
         )
         agent_deltas = Wallet(
+            address=0,
             base_in_wallet=-d_base_reserves,
             lp_in_wallet=+lp_out,
         )
         return market_deltas, agent_deltas
 
-    def _remove_liquidity(self, trade_details):
+    def _remove_liquidity(
+        self, agent_action: Agent.AgentAction, time_remaining: float, stretched_time_remaining: float
+    ) -> tuple[MarketDeltas, Wallet]:
         """
         Computes new deltas for bond & share reserves after liquidity is removed
         """
         lp_in, d_base_reserves, d_token_reserves = self.pricing_model.calc_tokens_out_given_lp_in(
-            lp_in=trade_details.trade_amount,
+            lp_in=agent_action.trade_amount,
             share_reserves=self.share_reserves,
             bond_reserves=self.bond_reserves,
             share_buffer=self.share_buffer,
@@ -572,20 +588,21 @@ class Market:
             share_price=self.share_price,
             lp_reserves=self.lp_reserves,
             rate=self.rate,
-            time_remaining=trade_details.time_remaining,
-            stretched_time_remaining=trade_details.stretched_time_remaining,
+            time_remaining=time_remaining,
+            stretched_time_remaining=stretched_time_remaining,
         )
         market_deltas = MarketDeltas(
             d_base_asset=-d_base_reserves,
             d_token_asset=-d_token_reserves,
             d_lp_reserves=-lp_in,
             d_lp_reserves_history=[
-                trade_details.mint_time,
-                trade_details.wallet_address,
-                -trade_details.trade_amount,
+                agent_action.mint_time,
+                agent_action.wallet_address,
+                -agent_action.trade_amount,
             ],
         )
         agent_deltas = Wallet(
+            address=0,
             base_in_wallet=+d_base_reserves,
             lp_in_wallet=-lp_in,
         )
@@ -658,7 +675,7 @@ class Market:
     #    else:
     #        return None
 
-    def get_market_step_string(self):
+    def get_market_step_string(self) -> str:
         """Returns a string that describes the current market step"""
         output_string = f"t={bcolors.HEADER}{self.time}{bcolors.ENDC}"
         output_string += (

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass, field
 
 import numpy as np
 from elfpy.pricing_models import ElementPricingModel, HyperdrivePricingModel, TradeResult
+from elfpy.token import TokenType
 
 import elfpy.utils.time as time_utils
-from elfpy.agent import Agent, AgentActionType, TokenType, TradeDirection
+from elfpy.agent import Agent, AgentActionType, TradeDirection
 import elfpy.utils.price as price_utils
 from elfpy.utils.bcolors import Bcolors as bcolors
 from elfpy.utils.outputs import float_to_string

--- a/src/elfpy/pricing_models.py
+++ b/src/elfpy/pricing_models.py
@@ -4,6 +4,10 @@ Pricing models implement automated market makers (AMMs)
 TODO: rewrite all functions to have typed inputs
 """
 
+
+from abc import ABC, abstractmethod
+from typing import NamedTuple
+from elfpy.token import TokenType
 import elfpy.utils.price as price_utils
 import elfpy.utils.time as time_utils
 
@@ -21,8 +25,19 @@ import elfpy.utils.time as time_utils
 #     we should consider how to break them up or delete this TODO if it's not possible
 # pylint: disable=too-many-locals
 
+class TradeResult(NamedTuple):
+    """
+    Result from a calc_out_given_in or calc_in_given_out.  The values are the amount of asset required
+    for the trade, either in or out.  Fee is the amount of fee collected, if any.
+    """
 
-class PricingModel:
+    without_fee_or_slippage: float
+    with_fee: float
+    without_fee: float
+    fee: float
+
+
+class PricingModel(ABC):
     """
     Contains functions for calculating AMM variables
 
@@ -42,41 +57,98 @@ class PricingModel:
         """
         self.verbose = False if verbose is None else verbose
 
+    @abstractmethod
     def calc_in_given_out(
         self,
-        out,
-        share_reserves,
-        bond_reserves,
-        token_in,
-        fee_percent,
-        time_remaining,
-        init_share_price,
-        share_price,
-    ):
+        out: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_in: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
         """Calculate fees and asset quantity adjustments"""
         raise NotImplementedError
 
+    @abstractmethod
     def calc_out_given_in(
         self,
-        in_,
-        share_reserves,
-        bond_reserves,
-        token_out,
-        fee_percent,
-        time_remaining,
-        init_share_price,
-        share_price,
-    ):
+        in_: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_out: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
         """Calculate fees and asset quantity adjustments"""
         raise NotImplementedError
 
-    def model_name(self):
+    @abstractmethod
+    def calc_lp_out_given_tokens_in(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        """
+        Computes the amount of LP tokens to be minted for a given amount of base asset"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def calc_lp_in_given_tokens_out(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        """
+        Computes the amount of LP tokens to be minted for a given amount of base asset"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def calc_tokens_out_given_lp_in(
+        self,
+        lp_in: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        """Calculate how many tokens should be returned for a given lp addition"""
+        raise NotImplementedError
+
+
+    @abstractmethod
+    def model_name(self) -> str:
         """Unique name given to the model, can be based on member variable states"""
         raise NotImplementedError
 
     def calc_spot_price_from_reserves(
-        self, share_reserves, bond_reserves, init_share_price, share_price, time_remaining
-    ):
+        self, share_reserves: float, bond_reserves: float, init_share_price: float, share_price: float, time_remaining: float
+    ) -> float:
         r"""
         Calculates the spot price of base in terms of bonds.
 
@@ -115,13 +187,13 @@ class PricingModel:
 
     def calc_apr_from_reserves(
         self,
-        share_reserves,
-        bond_reserves,
-        time_remaining,
-        time_stretch,
-        init_share_price=1,
-        share_price=1,
-    ):
+        share_reserves: float,
+        bond_reserves: float,
+        time_remaining: float,
+        time_stretch: float,
+        init_share_price: float=1,
+        share_price: float=1,
+    ) -> float:
         # TODO: Update this comment so that it matches the style of the other comments.
         """
         Returns the apr given reserve amounts
@@ -149,20 +221,20 @@ class ElementPricingModel(PricingModel):
     Does not use the Yield Bearing Vault `init_share_price` (μ) and `share_price` (c) variables.
     """
 
-    def model_name(self):
+    def model_name(self) -> str:
         return "Element"
 
     def calc_in_given_out(
         self,
-        out,
-        share_reserves,
-        bond_reserves,
-        token_in,
-        fee_percent,
-        time_remaining,
-        init_share_price=1,
-        share_price=1,
-    ):
+        out: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_in: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price=1.0,
+        share_price=1.0,
+    ) -> TradeResult:
         r"""
         Calculates the amount of an asset that must be provided to receive a
         specified amount of the other asset given the current AMM reserves.
@@ -346,19 +418,19 @@ class ElementPricingModel(PricingModel):
             without_fee >= 0
         ), f"pricing_models.calc_in_given_out: ERROR: without_fee should be non-negative, not {without_fee}!"
 
-        return (without_fee_or_slippage, with_fee, without_fee, fee)
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)
 
     def calc_out_given_in(
         self,
-        in_,
-        share_reserves,
-        bond_reserves,
-        token_out,
-        fee_percent,
-        time_remaining,
-        init_share_price=1,
-        share_price=1,
-    ):
+        in_: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_out: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float=1.0,
+        share_price: float=1.0,
+    ) -> TradeResult:
         r"""
         Calculates the amount of an asset that must be provided to receive a
         specified amount of the other asset given the current AMM reserves.
@@ -537,7 +609,7 @@ class ElementPricingModel(PricingModel):
             with_fee >= 0
         ), f"pricing_models.calc_out_given_in: ERROR: with_fee should be non-negative, not {with_fee}!"
 
-        return (without_fee_or_slippage, with_fee, without_fee, fee)
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)
 
 
 class HyperdrivePricingModel(PricingModel):
@@ -548,22 +620,22 @@ class HyperdrivePricingModel(PricingModel):
     enable the base reserves to be deposited into yield bearing vaults
     """
 
-    def model_name(self):
+    def model_name(self) -> str:
         return "Hyperdrive"
 
     def calc_lp_out_given_tokens_in(
         self,
-        d_base,
-        share_reserves,
-        bond_reserves,
-        share_buffer,
-        init_share_price,
-        share_price,
-        lp_reserves,
-        rate,
-        time_remaining,
-        stretched_time_remaining,
-    ):
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
         r"""
         Computes the amount of LP tokens to be minted for a given amount of base asset
 
@@ -630,17 +702,17 @@ class HyperdrivePricingModel(PricingModel):
 
     def calc_lp_in_given_tokens_out(
         self,
-        d_base,
-        share_reserves,
-        bond_reserves,
-        share_buffer,
-        init_share_price,
-        share_price,
-        lp_reserves,
-        rate,
-        time_remaining,
-        stretched_time_remaining,
-    ):
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
         r"""
         Computes the amount of LP tokens to be minted for a given amount of base asset
         .. math::
@@ -679,17 +751,17 @@ class HyperdrivePricingModel(PricingModel):
 
     def calc_tokens_out_given_lp_in(
         self,
-        lp_in,
-        share_reserves,
-        bond_reserves,
-        share_buffer,
-        init_share_price,
-        share_price,
-        lp_reserves,
-        rate,
-        time_remaining,
-        stretched_time_remaining,
-    ):
+        lp_in: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
         """Calculate how many tokens should be returned for a given lp addition"""
         assert lp_in > 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected lp_in > 0, not {lp_in}!"
         assert (
@@ -742,15 +814,15 @@ class HyperdrivePricingModel(PricingModel):
     # pylint: disable=too-many-locals
     def calc_in_given_out(
         self,
-        out,
-        share_reserves,
-        bond_reserves,
-        token_in,
-        fee_percent,
-        time_remaining,
-        init_share_price,
-        share_price,
-    ):
+        out: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_in: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
         r"""
         Calculates the amount of an asset that must be provided to receive a
         specified amount of the other asset given the current AMM reserves.
@@ -987,7 +1059,7 @@ class HyperdrivePricingModel(PricingModel):
             f"\n\twithout_fee={without_fee}\n\tfee={fee}"
         )
 
-        return (without_fee_or_slippage, with_fee, without_fee, fee)
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)
 
     # TODO: The high slippage tests in tests/test_pricing_model.py should
     # arguably have much higher slippage. This is something we should
@@ -996,15 +1068,15 @@ class HyperdrivePricingModel(PricingModel):
     # pylint: disable=too-many-locals
     def calc_out_given_in(
         self,
-        in_,
-        share_reserves,
-        bond_reserves,
-        token_out,
-        fee_percent,
-        time_remaining,
-        init_share_price,
-        share_price,
-    ):
+        in_: float,
+        share_reserves: float,
+        bond_reserves: float,
+        token_out: TokenType,
+        fee_percent: float,
+        time_remaining: float,
+        init_share_price: float,
+        share_price: float,
+    ) -> TradeResult:
         r"""
         Calculates the amount of an asset that must be provided to receive a
         specified amount of the other asset given the current AMM reserves.
@@ -1212,4 +1284,4 @@ class HyperdrivePricingModel(PricingModel):
             f"\n\twithout_fee={without_fee}\n\tfee={fee}"
         )
 
-        return (without_fee_or_slippage, with_fee, without_fee, fee)
+        return TradeResult(without_fee_or_slippage, with_fee, without_fee, fee)

--- a/src/elfpy/pricing_models.py
+++ b/src/elfpy/pricing_models.py
@@ -25,6 +25,7 @@ import elfpy.utils.time as time_utils
 #     we should consider how to break them up or delete this TODO if it's not possible
 # pylint: disable=too-many-locals
 
+
 class TradeResult(NamedTuple):
     """
     Result from a calc_out_given_in or calc_in_given_out.  The values are the amount of asset required
@@ -140,14 +141,18 @@ class PricingModel(ABC):
         """Calculate how many tokens should be returned for a given lp addition"""
         raise NotImplementedError
 
-
     @abstractmethod
     def model_name(self) -> str:
         """Unique name given to the model, can be based on member variable states"""
         raise NotImplementedError
 
     def calc_spot_price_from_reserves(
-        self, share_reserves: float, bond_reserves: float, init_share_price: float, share_price: float, time_remaining: float
+        self,
+        share_reserves: float,
+        bond_reserves: float,
+        init_share_price: float,
+        share_price: float,
+        time_remaining: float,
     ) -> float:
         r"""
         Calculates the spot price of base in terms of bonds.
@@ -191,8 +196,8 @@ class PricingModel(ABC):
         bond_reserves: float,
         time_remaining: float,
         time_stretch: float,
-        init_share_price: float=1,
-        share_price: float=1,
+        init_share_price: float = 1,
+        share_price: float = 1,
     ) -> float:
         # TODO: Update this comment so that it matches the style of the other comments.
         """
@@ -220,6 +225,51 @@ class ElementPricingModel(PricingModel):
     Element v1 pricing model
     Does not use the Yield Bearing Vault `init_share_price` (μ) and `share_price` (c) variables.
     """
+
+    def calc_lp_out_given_tokens_in(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        raise NotImplementedError
+
+    def calc_lp_in_given_tokens_out(
+        self,
+        d_base: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        raise NotImplementedError
+
+    def calc_tokens_out_given_lp_in(
+        self,
+        lp_in: float,
+        share_reserves: float,
+        bond_reserves: float,
+        share_buffer: float,
+        init_share_price: float,
+        share_price: float,
+        lp_reserves: float,
+        rate: float,
+        time_remaining: float,
+        stretched_time_remaining: float,
+    ) -> tuple[float, float, float]:
+        raise NotImplementedError
 
     def model_name(self) -> str:
         return "Element"
@@ -428,8 +478,8 @@ class ElementPricingModel(PricingModel):
         token_out: TokenType,
         fee_percent: float,
         time_remaining: float,
-        init_share_price: float=1.0,
-        share_price: float=1.0,
+        init_share_price: float = 1.0,
+        share_price: float = 1.0,
     ) -> TradeResult:
         r"""
         Calculates the amount of an asset that must be provided to receive a

--- a/src/elfpy/simulators.py
+++ b/src/elfpy/simulators.py
@@ -5,6 +5,7 @@ for experiment tracking and execution
 TODO: rewrite all functions to have typed inputs
 """
 
+from __future__ import annotations
 import datetime
 from importlib import import_module
 import json

--- a/src/elfpy/strategies/basic.py
+++ b/src/elfpy/strategies/basic.py
@@ -5,7 +5,7 @@ Policies inherit from Users (thus each policy is assigned to a user)
 subclasses of BasicPolicy will implement trade actions
 """
 
-from elfpy.user import User
+ import User
 
 
 class BasicPolicy(User):

--- a/src/elfpy/strategies/basic.py
+++ b/src/elfpy/strategies/basic.py
@@ -5,10 +5,10 @@ Policies inherit from Users (thus each policy is assigned to a user)
 subclasses of BasicPolicy will implement trade actions
 """
 
- import User
+from elfpy.agent import Agent
 
 
-class BasicPolicy(User):
+class BasicPolicy(Agent):
     """
     most basic policy setup
     """

--- a/src/elfpy/strategies/single_short.py
+++ b/src/elfpy/strategies/single_short.py
@@ -33,7 +33,7 @@ class Policy(BasicPolicy):
         action_list = []
         block_position_list = list(self.wallet.token_in_protocol.values())
         has_opened_short = bool(any((x < -1 for x in block_position_list)))
-        can_open_short = self.get_max_pt_short(self.market.time) >= self.pt_to_short
+        can_open_short = self.get_max_pt_short() >= self.pt_to_short
         if can_open_short and not has_opened_short:
             action_list.append(self.create_agent_action(action_type="open_short", trade_amount=self.pt_to_short))
         return action_list

--- a/src/elfpy/token.py
+++ b/src/elfpy/token.py
@@ -1,0 +1,5 @@
+
+from typing import Literal
+
+
+TokenType = Literal["pt", "base"]

--- a/src/elfpy/token.py
+++ b/src/elfpy/token.py
@@ -1,4 +1,3 @@
-
 from typing import Literal
 
 

--- a/src/elfpy/token.py
+++ b/src/elfpy/token.py
@@ -1,3 +1,6 @@
+"""
+Typing for expected types of tokens that will be used in simulation.
+"""
 from typing import Literal
 
 

--- a/src/elfpy/utils/parse_config.py
+++ b/src/elfpy/utils/parse_config.py
@@ -4,15 +4,17 @@ Utilities for parsing & loading user config TOML files
 TODO: change floor_fee to be a decimal like min_fee and max_fee
 """
 
-# pylint: disable=too-many-instance-attributes
 
-import tomli
 from dataclasses import dataclass, field
+import tomli
 
 
 @dataclass
 class MarketConfig:
     """config parameters specific to the market"""
+
+    # pylint: disable=too-many-instance-attributes
+    # dataclasses can have many attributes
 
     min_target_liquidity: float = field(default=1e6, metadata={"hint": "shares"})
     max_target_liquidity: float = field(default=10e6, metadata={"hint": "shares"})
@@ -40,6 +42,9 @@ class AMMConfig:
 @dataclass
 class SimulatorConfig:
     """config parameters specific to the simulator"""
+
+    # pylint: disable=too-many-instance-attributes
+    # dataclasses can have many attributes
 
     pool_duration: int = field(default=180, metadata={"hint": "in days"})
     num_trading_days: int = field(default=180, metadata={"hint": "in days; should be <= pool_duration"})

--- a/src/elfpy/utils/parse_config.py
+++ b/src/elfpy/utils/parse_config.py
@@ -6,11 +6,8 @@ TODO: change floor_fee to be a decimal like min_fee and max_fee
 
 # pylint: disable=too-many-instance-attributes
 
-
-from dataclasses import dataclass, field
-
-
 import tomli
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -57,6 +54,14 @@ class SimulatorConfig:
     init_lp: bool = field(default=True, metadata={"hint": "use initial LP to seed pool"})
     random_seed: int = field(default=1, metadata={"hint": "int to be used for the random seed"})
     verbose: bool = field(default=False, metadata={"hint": "verbosity level for logging"})
+    target_liquidity: float = field(default=0, metadata={"hint": ""})
+    target_daily_volume: float = field(default=0, metadata={"hint": "daily volume in base asset of trades"})
+    init_pool_apy: float = field(default=0, metadata={"hint": "initial pool apy"})
+    fee_percent: float = field(default=0, metadata={"hint": ""})
+    init_vault_age: float = field(default=0, metadata={"hint": "initial vault age"})
+    vault_apy: list[float] = field(
+        default_factory=list, metadata={"hint": "the underlying (variable) vault apy at each time step"}
+    )
 
 
 @dataclass

--- a/src/elfpy/utils/price.py
+++ b/src/elfpy/utils/price.py
@@ -54,8 +54,8 @@ def calc_liquidity(
     apr,
     days_remaining,
     time_stretch,
-    init_share_price=1,
-    share_price=1,
+    init_share_price: float = 1,
+    share_price: float = 1,
 ):
     """
     Returns the reserve volumes and total supply

--- a/src/elfpy/utils/time.py
+++ b/src/elfpy/utils/time.py
@@ -14,13 +14,13 @@ def current_datetime() -> datetime:
     return datetime.now(pytz.timezone("Etc/GMT-0"))
 
 
-def block_number_to_datetime(start_time: timedelta, block_number: float, time_between_blocks: float) -> timedelta:
+def block_number_to_datetime(start_time: datetime, block_number: float, time_between_blocks: float) -> datetime:
     """Converts the current block number to a datetime based on the start datetime of the simulation"""
     delta_time = timedelta(seconds=block_number * time_between_blocks)
     return start_time + delta_time
 
 
-def yearfrac_as_datetime(start_time: timedelta, yearfrac: float) -> timedelta:
+def yearfrac_as_datetime(start_time: datetime, yearfrac: float) -> datetime:
     """Returns a yearfrac (e.g. the current market time) in datetime format"""
     dayfrac = yearfrac * 365
     delta_time = timedelta(days=dayfrac)

--- a/src/elfpy/utils/time.py
+++ b/src/elfpy/utils/time.py
@@ -3,65 +3,65 @@ Helper functions for converting time units
 """
 
 
-import datetime
+from datetime import datetime, timedelta
 import pytz
 
 import numpy as np
 
 
-def current_datetime():
+def current_datetime() -> datetime:
     """Returns the current time"""
-    return datetime.datetime.now(pytz.timezone("Etc/GMT-0"))
+    return datetime.now(pytz.timezone("Etc/GMT-0"))
 
 
-def block_number_to_datetime(start_time, block_number, time_between_blocks):
+def block_number_to_datetime(start_time: timedelta, block_number: float, time_between_blocks: float) -> timedelta:
     """Converts the current block number to a datetime based on the start datetime of the simulation"""
-    delta_time = datetime.timedelta(seconds=block_number * time_between_blocks)
+    delta_time = timedelta(seconds=block_number * time_between_blocks)
     return start_time + delta_time
 
 
-def yearfrac_as_datetime(start_time, yearfrac):
+def yearfrac_as_datetime(start_time: timedelta, yearfrac: float) -> timedelta:
     """Returns a yearfrac (e.g. the current market time) in datetime format"""
     dayfrac = yearfrac * 365
-    delta_time = datetime.timedelta(days=dayfrac)
+    delta_time = timedelta(days=dayfrac)
     return start_time + delta_time
 
 
-def get_yearfrac_remaining(market_time, mint_time, token_duration):
+def get_yearfrac_remaining(market_time: float, mint_time: float, token_duration: float) -> float:
     """Get the year fraction remaining on a token"""
     yearfrac_elapsed = market_time - mint_time
     time_remaining = np.maximum(token_duration - yearfrac_elapsed, 0)
     return time_remaining
 
 
-def norm_days(days, normalizing_constant=365):
+def norm_days(days: float, normalizing_constant: float = 365) -> float:
     """Returns days normalized between 0 and 1, with a default assumption of a year-long scale"""
     return days / normalizing_constant
 
 
-def stretch_time(time, time_stretch=1.0):
+def stretch_time(time: float, time_stretch: float = 1.0) -> float:
     """Returns stretched time values"""
     return time / time_stretch
 
 
-def unnorm_days(normed_days, normalizing_constant=365):
+def unnorm_days(normed_days: float, normalizing_constant: float = 365) -> float:
     """Returns days from a value between 0 and 1"""
     return normed_days * normalizing_constant
 
 
-def unstretch_time(stretched_time, time_stretch=1):
+def unstretch_time(stretched_time: float, time_stretch: float = 1) -> float:
     """Returns unstretched time value, which should be between 0 and 1"""
     return stretched_time * time_stretch
 
 
-def days_to_time_remaining(days_remaining, time_stretch=1, normalizing_constant=365):
+def days_to_time_remaining(days_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365) -> float:
     """Converts remaining pool length in days to normalized and stretched time"""
     normed_days_remaining = norm_days(days_remaining, normalizing_constant)
     time_remaining = stretch_time(normed_days_remaining, time_stretch)
     return time_remaining
 
 
-def time_to_days_remaining(time_remaining, time_stretch=1, normalizing_constant=365):
+def time_to_days_remaining(time_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365) -> float:
     """Converts normalized and stretched time remaining in pool to days"""
     normed_days_remaining = unstretch_time(time_remaining, time_stretch)
     days_remaining = unnorm_days(normed_days_remaining, normalizing_constant)

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -18,6 +18,7 @@ class Wallet:
     # pylint: disable=duplicate-code
 
     # fungible
+    address: str
     base_in_wallet: float
     lp_in_wallet: float = 0  # they're fungible!
     fees_paid: float = 0

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -1,0 +1,57 @@
+"""
+Implements abstract classes that control user behavior
+
+TODO: rewrite all functions to have typed inputs
+"""
+
+from dataclasses import dataclass
+from dataclasses import field
+
+from elfpy.utils.outputs import float_to_string
+
+
+@dataclass(frozen=False)
+class Wallet:
+    """Stores what's in the agent's wallet"""
+
+    # TODO: Create our own dataclass decorator that is always mutable and includes dict set/get syntax
+    # pylint: disable=duplicate-code
+
+    # fungible
+    base_in_wallet: float
+    lp_in_wallet: float = 0  # they're fungible!
+    fees_paid: float = 0
+    # non-fungible (identified by mint_time, stored as dict)
+    token_in_wallet: dict = field(default_factory=dict)
+    base_in_protocol: dict = field(default_factory=dict)
+    token_in_protocol: dict = field(default_factory=dict)
+    effective_price: float = field(init=False)  # calculated after init, only for transactions
+
+    def __post_init__(self):
+        """Post initialization function"""
+        # check if this represents a trade (one side will be negative)
+        total_tokens = sum(list(self.token_in_wallet.values()))
+        if self.base_in_wallet < 0 or total_tokens < 0:
+            self.effective_price = total_tokens / self.base_in_wallet
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
+
+    def __str__(self):
+        output_string = ""
+        for key, value in vars(self).items():
+            if value:  #  check if object exists
+                if value != 0:
+                    output_string += f" {key}: "
+                    if isinstance(value, float):
+                        output_string += f"{float_to_string(value)}"
+                    elif isinstance(value, list):
+                        output_string += "[" + ", ".join([float_to_string(x) for x in value]) + "]"
+                    elif isinstance(value, dict):
+                        output_string += "{" + ", ".join([f"{k}: {float_to_string(v)}" for k, v in value.items()]) + "}"
+                    else:
+                        output_string += f"{value}"
+        return output_string

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -16,7 +16,7 @@ class Wallet:
     # pylint: disable=duplicate-code
 
     # fungible
-    address: str
+    address: int
     base_in_wallet: float
     lp_in_wallet: float = 0  # they're fungible!
     fees_paid: float = 0

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -1,7 +1,5 @@
 """
 Implements abstract classes that control user behavior
-
-TODO: rewrite all functions to have typed inputs
 """
 
 from dataclasses import dataclass

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -12,8 +12,8 @@ from elfpy.utils.outputs import float_to_string
 class Wallet:
     """Stores what's in the agent's wallet"""
 
-    # TODO: Create our own dataclass decorator that is always mutable and includes dict set/get syntax
-    # pylint: disable=duplicate-code
+    # pylint: disable=too-many-instance-attributes
+    # dataclasses can have many attributes
 
     # fungible
     address: int


### PR DESCRIPTION
The commits tell a story, but a lot of it is me chasing down type hints and fixing weird bugs because of it.  Might be easier to just look at the overall diffs. 

I mostly concentrated on agent.py and market.py which leaked out to pricing_models.py and a few other files.  I'm cutting myself off at this point to make sure I haven't broken anything.  While I was mostly adding type hints, I was doing drive-by cleanup as well.  For reviewing this PR, please make sure logic changes in places you've authored didn't break. 