### PR TITLE
Updated the flat+curve model to modify the amount of base

### DIFF
--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -114,7 +114,7 @@ class Market:
             # TODO: We should improve the StretchedTime API so that it accepts yearfracs in
             # the place of days remaining.
             days=time_utils.get_yearfrac_remaining(
-                self.time, agent_action.mint_time, self.position_duration.normalized_days
+                self.time, agent_action.mint_time, self.position_duration.normalized_time
             )
             * 365,
             time_stretch=self.position_duration.time_stretch,
@@ -148,14 +148,14 @@ class Market:
             market_deltas, agent_deltas = self._add_liquidity(
                 pricing_model=pricing_model,
                 agent_action=agent_action,
-                time_remaining=time_remaining.normalized_days,
+                time_remaining=time_remaining.normalized_time,
                 stretched_time_remaining=time_remaining.stretched_time,
             )
         elif agent_action.action_type == MarketActionType.REMOVE_LIQUIDITY:
             market_deltas, agent_deltas = self._remove_liquidity(
                 pricing_model=pricing_model,
                 agent_action=agent_action,
-                time_remaining=time_remaining.normalized_days,
+                time_remaining=time_remaining.normalized_time,
                 stretched_time_remaining=time_remaining.stretched_time,
             )
         else:

--- a/src/elfpy/pricing_models/hyperdrive.py
+++ b/src/elfpy/pricing_models/hyperdrive.py
@@ -96,11 +96,11 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
         # Redeem the matured bonds 1:1 and simulate these updates hitting the
         # reserves.
         if out.unit == TokenType.BASE:
-            market_state.share_reserves -= out.amount * (1 - time_remaining.normalized_days) / market_state.share_price
-            market_state.bond_reserves += out.amount * (1 - time_remaining.normalized_days)
+            market_state.share_reserves -= out.amount * (1 - time_remaining.normalized_time) / market_state.share_price
+            market_state.bond_reserves += out.amount * (1 - time_remaining.normalized_time)
         elif out.unit == TokenType.PT:
-            market_state.share_reserves += out.amount * (1 - time_remaining.normalized_days) / market_state.share_price
-            market_state.bond_reserves -= out.amount * (1 - time_remaining.normalized_days)
+            market_state.share_reserves += out.amount * (1 - time_remaining.normalized_time) / market_state.share_price
+            market_state.bond_reserves -= out.amount * (1 - time_remaining.normalized_time)
         else:
             raise AssertionError(
                 f"pricing_models.calc_in_given_out: ERROR: expected out.unit to be {TokenType.BASE} or {TokenType.PT}, not {out.unit}!"
@@ -108,7 +108,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Trade the bonds that haven't matured on the YieldSpace curve.
         curve = super().calc_in_given_out(
-            out=Quantity(amount=out.amount * time_remaining.normalized_days, unit=out.unit),
+            out=Quantity(amount=out.amount * time_remaining.normalized_time, unit=out.unit),
             market_state=market_state,
             fee_percent=fee_percent,
             time_remaining=StretchedTime(days=365, time_stretch=time_remaining.time_stretch),
@@ -116,7 +116,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Compute the user's trade result including both the flat and the curve
         # parts of the trade.
-        flat = out.amount * (1 - time_remaining.normalized_days)
+        flat = out.amount * (1 - time_remaining.normalized_time)
         if out.unit == TokenType.BASE:
             user_result = UserTradeResult(
                 d_base=out.amount,
@@ -212,14 +212,14 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
         # reserves.
         if in_.unit == TokenType.BASE:
             market_state.share_reserves += (
-                in_.amount * (1 - time_remaining.normalized_days)
+                in_.amount * (1 - time_remaining.normalized_time)
             ) / market_state.share_price
-            market_state.bond_reserves -= in_.amount * (1 - time_remaining.normalized_days)
+            market_state.bond_reserves -= in_.amount * (1 - time_remaining.normalized_time)
         elif in_.unit == TokenType.PT:
             market_state.share_reserves -= (
-                in_.amount * (1 - time_remaining.normalized_days)
+                in_.amount * (1 - time_remaining.normalized_time)
             ) / market_state.share_price
-            market_state.bond_reserves += in_.amount * (1 - time_remaining.normalized_days)
+            market_state.bond_reserves += in_.amount * (1 - time_remaining.normalized_time)
         else:
             raise AssertionError(
                 f"pricing_models.calc_out_given_in: ERROR: expected in_.unit to be {TokenType.BASE} or {TokenType.PT}, not {in_.unit}!"
@@ -227,7 +227,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Trade the bonds that haven't matured on the YieldSpace curve.
         curve = super().calc_out_given_in(
-            in_=Quantity(amount=in_.amount * time_remaining.normalized_days, unit=in_.unit),
+            in_=Quantity(amount=in_.amount * time_remaining.normalized_time, unit=in_.unit),
             market_state=market_state,
             fee_percent=fee_percent,
             time_remaining=StretchedTime(days=365, time_stretch=time_remaining.time_stretch),
@@ -235,7 +235,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Compute the user's trade result including both the flat and the curve
         # parts of the trade.
-        flat = in_.amount * (1 - time_remaining.normalized_days)
+        flat = in_.amount * (1 - time_remaining.normalized_time)
         if in_.unit == TokenType.BASE:
             user_result = UserTradeResult(
                 d_base=-in_.amount,

--- a/src/elfpy/pricing_models/hyperdrive.py
+++ b/src/elfpy/pricing_models/hyperdrive.py
@@ -4,6 +4,7 @@ import copy
 
 from elfpy.pricing_models.yieldspace import YieldSpacePricingModel
 from elfpy.types import (
+    MarketTradeResult,
     Quantity,
     MarketState,
     StretchedTime,
@@ -95,11 +96,11 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
         # Redeem the matured bonds 1:1 and simulate these updates hitting the
         # reserves.
         if out.unit == TokenType.BASE:
-            market_state.share_reserves -= out.amount * (1 - time_remaining.stretched_time) / market_state.share_price
-            market_state.bond_reserves += out.amount * (1 - time_remaining.stretched_time)
+            market_state.share_reserves -= out.amount * (1 - time_remaining.normalized_days) / market_state.share_price
+            market_state.bond_reserves += out.amount * (1 - time_remaining.normalized_days)
         elif out.unit == TokenType.PT:
-            market_state.share_reserves += out.amount * (1 - time_remaining.stretched_time) / market_state.share_price
-            market_state.bond_reserves -= out.amount * (1 - time_remaining.stretched_time)
+            market_state.share_reserves += out.amount * (1 - time_remaining.normalized_days) / market_state.share_price
+            market_state.bond_reserves -= out.amount * (1 - time_remaining.normalized_days)
         else:
             raise AssertionError(
                 f"pricing_models.calc_in_given_out: ERROR: expected out.unit to be {TokenType.BASE} or {TokenType.PT}, not {out.unit}!"
@@ -107,7 +108,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Trade the bonds that haven't matured on the YieldSpace curve.
         curve = super().calc_in_given_out(
-            out=Quantity(amount=out.amount * time_remaining.stretched_time, unit=out.unit),
+            out=Quantity(amount=out.amount * time_remaining.normalized_days, unit=out.unit),
             market_state=market_state,
             fee_percent=fee_percent,
             time_remaining=StretchedTime(days=365, time_stretch=time_remaining.time_stretch),
@@ -115,16 +116,24 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Compute the user's trade result including both the flat and the curve
         # parts of the trade.
-        flat = out.amount * (1 - time_remaining.stretched_time)
+        flat = out.amount * (1 - time_remaining.normalized_days)
         if out.unit == TokenType.BASE:
             user_result = UserTradeResult(
                 d_base=out.amount,
                 d_bonds=-flat + curve.user_result.d_bonds,
             )
+            market_result = MarketTradeResult(
+                d_base=-out.amount,
+                d_bonds=curve.market_result.d_bonds,
+            )
         elif out.unit == TokenType.PT:
             user_result = UserTradeResult(
                 d_base=-flat + curve.user_result.d_base,
                 d_bonds=out.amount,
+            )
+            market_result = MarketTradeResult(
+                d_base=flat + curve.market_result.d_base,
+                d_bonds=curve.market_result.d_bonds,
             )
         else:
             raise AssertionError(
@@ -133,7 +142,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         return TradeResult(
             user_result=user_result,
-            market_result=curve.market_result,
+            market_result=market_result,
             breakdown=TradeBreakdown(
                 without_fee_or_slippage=flat + curve.breakdown.without_fee_or_slippage,
                 without_fee=flat + curve.breakdown.without_fee,
@@ -202,11 +211,15 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
         # Redeem the matured bonds 1:1 and simulate these updates hitting the
         # reserves.
         if in_.unit == TokenType.BASE:
-            market_state.share_reserves += (in_.amount * (1 - time_remaining.stretched_time)) / market_state.share_price
-            market_state.bond_reserves -= in_.amount * (1 - time_remaining.stretched_time)
+            market_state.share_reserves += (
+                in_.amount * (1 - time_remaining.normalized_days)
+            ) / market_state.share_price
+            market_state.bond_reserves -= in_.amount * (1 - time_remaining.normalized_days)
         elif in_.unit == TokenType.PT:
-            market_state.share_reserves -= (in_.amount * (1 - time_remaining.stretched_time)) / market_state.share_price
-            market_state.bond_reserves += in_.amount * (1 - time_remaining.stretched_time)
+            market_state.share_reserves -= (
+                in_.amount * (1 - time_remaining.normalized_days)
+            ) / market_state.share_price
+            market_state.bond_reserves += in_.amount * (1 - time_remaining.normalized_days)
         else:
             raise AssertionError(
                 f"pricing_models.calc_out_given_in: ERROR: expected in_.unit to be {TokenType.BASE} or {TokenType.PT}, not {in_.unit}!"
@@ -214,7 +227,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Trade the bonds that haven't matured on the YieldSpace curve.
         curve = super().calc_out_given_in(
-            in_=Quantity(amount=in_.amount * time_remaining.stretched_time, unit=in_.unit),
+            in_=Quantity(amount=in_.amount * time_remaining.normalized_days, unit=in_.unit),
             market_state=market_state,
             fee_percent=fee_percent,
             time_remaining=StretchedTime(days=365, time_stretch=time_remaining.time_stretch),
@@ -222,16 +235,24 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         # Compute the user's trade result including both the flat and the curve
         # parts of the trade.
-        flat = in_.amount * (1 - time_remaining.stretched_time)
+        flat = in_.amount * (1 - time_remaining.normalized_days)
         if in_.unit == TokenType.BASE:
             user_result = UserTradeResult(
                 d_base=-in_.amount,
                 d_bonds=flat + curve.user_result.d_bonds,
             )
+            market_result = MarketTradeResult(
+                d_base=in_.amount,
+                d_bonds=curve.market_result.d_bonds,
+            )
         elif in_.unit == TokenType.PT:
             user_result = UserTradeResult(
                 d_base=flat + curve.user_result.d_base,
                 d_bonds=-in_.amount,
+            )
+            market_result = MarketTradeResult(
+                d_base=-flat + curve.market_result.d_base,
+                d_bonds=curve.market_result.d_bonds,
             )
         else:
             raise AssertionError(
@@ -240,7 +261,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
 
         return TradeResult(
             user_result=user_result,
-            market_result=curve.market_result,
+            market_result=market_result,
             breakdown=TradeBreakdown(
                 without_fee_or_slippage=flat + curve.breakdown.without_fee_or_slippage,
                 without_fee=flat + curve.breakdown.without_fee,

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -51,7 +51,7 @@ class StretchedTime:
         return self._days
 
     @property
-    def normalized_days(self):
+    def normalized_time(self):
         """Format time as normalized days."""
         return time_utils.norm_days(self._days)
 
@@ -69,7 +69,7 @@ class StretchedTime:
         out_str = (
             "Time components:"
             f" {self.days=};"
-            f" {self.normalized_days=};"
+            f" {self.normalized_time=};"
             f" {self.stretched_time=};"
             f" {self.time_stretch=};"
         )

--- a/src/elfpy/utils/price.py
+++ b/src/elfpy/utils/price.py
@@ -78,7 +78,7 @@ def calc_base_asset_reserves(
     """
     numerator = 2 * share_price * token_asset_reserves  # 2*c*y
     denominator = (
-        init_share_price * (1 + apr * time_remaining.normalized_days) ** (1 / time_remaining.stretched_time)
+        init_share_price * (1 + apr * time_remaining.normalized_time) ** (1 / time_remaining.stretched_time)
         - share_price
     )
     result = numerator / denominator  # 2*c*y/(u*(r*t + 1)**(1/T) - c)
@@ -158,7 +158,7 @@ def calc_apr_from_spot_price(price: float, time_remaining: StretchedTime):
     ---------
     price : float
         Spot price of bonds in terms of base
-    normalized_days_remaining : StretchedTime
+    normalized_time_remaining : StretchedTime
         Time remaining until bond maturity, in yearfracs
 
     Returns
@@ -170,11 +170,11 @@ def calc_apr_from_spot_price(price: float, time_remaining: StretchedTime):
         "utils.price.calc_apr_from_spot_price: ERROR: "
         f"Price argument should be greater or equal to zero, not {price}"
     )
-    assert time_remaining.normalized_days > 0, (
+    assert time_remaining.normalized_time > 0, (
         "utils.price.calc_apr_from_spot_price: ERROR: "
-        f"time_remaining.normalized_days should be greater than zero, not {time_remaining.normalized_days}"
+        f"time_remaining.normalized_time should be greater than zero, not {time_remaining.normalized_time}"
     )
-    return (1 - price) / (price * time_remaining.normalized_days)  # price = 1 / (1 + r * t)
+    return (1 - price) / (price * time_remaining.normalized_time)  # price = 1 / (1 + r * t)
 
 
 def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
@@ -193,7 +193,7 @@ def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
     float
         Spot price of bonds in terms of base, calculated from the provided parameters
     """
-    return 1 / (1 + apr * time_remaining.normalized_days)  # price = 1 / (1 + r * t)
+    return 1 / (1 + apr * time_remaining.normalized_time)  # price = 1 / (1 + r * t)
 
 
 ### YieldSpace ###

--- a/tests/utils/test_price_utils.py
+++ b/tests/utils/test_price_utils.py
@@ -677,7 +677,7 @@ class TestPriceUtils(unittest.TestCase):
             },
             # test 8: ERROR CASE
             #   0.95 price; -3mo remaining (negative);
-            #   the function asserts that normalized_days_remaining > 0, so this case \
+            #   the function asserts that normalized_time_remaining > 0, so this case \
             #   should raise an AssertionError
             {
                 "price": 0.95,  # 0% APR


### PR DESCRIPTION
This PR resulted in several changes (in order of importance):
1. The flat+curve model needs to update the base reserves in the market by the flat + curve amount (rather than just the curve amount). This ensures that the market always has an accurate perspective of the base that it holds rather than the market's `base_reserves` and the actual base value of the market steadily diverging over time.
2. Fixed a bug in the flat+curve model where stretched time was being used erroneously to compute the partition of tokens that should be traded on flat and curve, respectively.
3. Renamed `normalized_days` to `normalized_time`.