### PR TITLE
simplify time

### DIFF
--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -47,10 +47,17 @@ class Market:
         position_duration: StretchedTime = StretchedTime(365, 1),
     ):
         # market state variables
-        self.time: float = 0  # t: timefrac unit is time normalized to 1 year, i.e. 0.5 = 1/2 year
+        self._time: StretchedTime = StretchedTime(
+            days=0, time_stretch=position_duration.time_stretch
+        )  # t: timefrac unit is time normalized to 1 year, i.e. 0.5 = 1/2 year
         self.market_state: MarketState = market_state
         self.fee_percent: float = fee_percent  # g
         self.position_duration: StretchedTime = position_duration  # how long do positions take to mature
+
+    @property
+    def time(self) -> float:
+        """Get the current time in the market"""
+        return self._time.normalized_time
 
     def check_action_type(self, action_type: MarketActionType, pricing_model_name: str) -> None:
         """Ensure that the agent action is an allowed action for this market
@@ -198,8 +205,23 @@ class Market:
         return state_string
 
     def tick(self, delta_time: float) -> None:
-        """Increments the time member variable"""
-        self.time += delta_time
+        """
+        Increments the time member variable
+
+        Arguments
+        ---------
+        delta_time: float
+            time between blocks, which is computed as 1 / blocks_per_year
+            in units of years
+            calculated in simulators.py by market_step_size()
+
+        Returns
+        ---------
+        float
+            current market time, after being incremented by delta_time
+            in units of years
+        """
+        self._time += delta_time
 
     def _open_short(
         self,

--- a/src/elfpy/simulators.py
+++ b/src/elfpy/simulators.py
@@ -153,6 +153,7 @@ class Simulator:
         ---------
         float
             time between blocks, which is computed as 1 / blocks_per_year
+            in units of years
         """
         blocks_per_year = 365 * self.config.simulator.num_blocks_per_day
         return 1 / blocks_per_year

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -41,29 +41,35 @@ class StretchedTime:
     # TODO: Improve this constructor so that StretchedTime can be constructed
     # from yearfracs.
     def __init__(self, days: float, time_stretch: float):
-        self._days = days
+        self._years = days * 365
         self._time_stretch = time_stretch
-        self._stretched_time = time_utils.days_to_time_remaining(self._days, self._time_stretch)
 
     @property
     def days(self):
-        """Format time as days."""
-        return self._days
+        """Return time in days"""
+        return self._years * 365
 
     @property
     def normalized_time(self):
-        """Format time as normalized days."""
-        return time_utils.norm_days(self._days)
+        """Return time in years"""
+        return self._years
 
     @property
     def stretched_time(self):
-        """Format time as stretched time."""
-        return self._stretched_time
+        """Return as stretched time"""
+        return time_utils.days_to_time_remaining(self._days, self._time_stretch)
 
     @property
     def time_stretch(self):
         """The time stretch constant."""
         return self._time_stretch
+
+    def __iadd__(self, other):
+        """Add a time to this time"""
+        if isinstance(other, StretchedTime):
+            other = other.normalized_time
+        self._years += other
+        return self
 
     def __str__(self):
         out_str = (
@@ -146,6 +152,7 @@ class MarketDeltas:
 class MarketState:
     """The state of an AMM
     TODO: We can add class methods for computing common quantities like bond_reserves + total_supply
+    TODO: should MarketState contain a Time or StretchedTime object? maybe StretchedTime is suclass of Time?
     """
 
     # dataclasses can have many attributes


### PR DESCRIPTION
StretchedTime stores only one internal representation, in years (_years)
- days returns a function of _years
- normalized_time returns _years
- stretched_time returns a function of _days (could be changed to _years, that's just how current util function is set up)
