### PR TITLE
Fixed rounding issues in the pricing model

### DIFF
--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -2,10 +2,17 @@
 
 from abc import ABC, abstractmethod
 import copy
+import decimal
 from decimal import Decimal
 
 from elfpy.types import MarketDeltas, Quantity, MarketState, StretchedTime, TokenType, TradeResult
 import elfpy.utils.price as price_utils
+
+# Set the Decimal precision to be higher than the default of 28. This ensures
+# that the pricing models can safely a lowest possible input of 1e-18 with an
+# opposing reserves of over 1 billion (although this should be viewed as a cap
+# to give the market room for interest to accrue over time).
+decimal.getcontext().prec = 30
 
 
 class PricingModel(ABC):
@@ -373,8 +380,9 @@ class PricingModel(ABC):
     ):
         """Applies a set of assertions to the input of a trading function."""
 
-        assert quantity.amount > 0, (
-            "pricing_models.check_input_assertions: ERROR: " f"expected quantity.amount > 0, not {quantity.amount}!"
+        assert quantity.amount >= 1e-18, (
+            "pricing_models.check_input_assertions: ERROR: "
+            f"expected quantity.amount >= 1e-18, not {quantity.amount}!"
         )
         assert market_state.share_reserves >= 0, (
             "pricing_models.check_input_assertions: ERROR: "

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -193,7 +193,7 @@ class PricingModel(ABC):
 
         .. math::
             \begin{align}
-            p = (\frac{y + cz}{\mu z})^{-\tau}
+            p = (\frac{2y + cz}{\mu z})^{-\tau}
             \end{align}
 
         Arguments
@@ -222,7 +222,7 @@ class PricingModel(ABC):
 
         .. math::
             \begin{align}
-            p = (\frac{y + cz}{\mu z})^{-\tau}
+            p = (\frac{2y + cz}{\mu z})^{-\tau}
             \end{align}
 
         Arguments

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -208,15 +208,18 @@ class PricingModel(ABC):
         float
             The spot price of principal tokens.
         """
-        return float(self._calc_spot_price_from_reserves(market_state=market_state, time_remaining=time_remaining))
+        return float(
+            self._calc_spot_price_from_reserves_high_precision(market_state=market_state, time_remaining=time_remaining)
+        )
 
-    def _calc_spot_price_from_reserves(
+    def _calc_spot_price_from_reserves_high_precision(
         self,
         market_state: MarketState,
         time_remaining: StretchedTime,
     ) -> Decimal:
         r"""
-        Calculates the spot price of base in terms of bonds.
+        Calculates the spot price of base in terms of bonds. This variant returns
+        the result in a high precision format.
 
         The spot price is defined as:
 

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -5,7 +5,16 @@ import copy
 import decimal
 from decimal import Decimal
 
-from elfpy.types import MarketDeltas, Quantity, MarketState, StretchedTime, TokenType, TradeResult
+from elfpy.types import (
+    MAX_RESERVES_DIFFERENCE,
+    WEI,
+    MarketDeltas,
+    Quantity,
+    MarketState,
+    StretchedTime,
+    TokenType,
+    TradeResult,
+)
 import elfpy.utils.price as price_utils
 
 # Set the Decimal precision to be higher than the default of 28. This ensures
@@ -382,17 +391,17 @@ class PricingModel(ABC):
     ):
         """Applies a set of assertions to the input of a trading function."""
 
-        assert quantity.amount >= 1e-18, (
+        assert quantity.amount >= WEI, (
             "pricing_models.check_input_assertions: ERROR: "
-            f"expected quantity.amount >= 1e-18, not {quantity.amount}!"
+            f"expected quantity.amount >= {WEI}, not {quantity.amount}!"
         )
-        assert market_state.share_reserves >= 1e-18, (
+        assert market_state.share_reserves >= WEI, (
             "pricing_models.check_input_assertions: ERROR: "
-            f"expected share_reserves >= 1e-18, not {market_state.share_reserves}!"
+            f"expected share_reserves >= {WEI}, not {market_state.share_reserves}!"
         )
-        assert market_state.bond_reserves >= 1e-18 or market_state.bond_reserves == 0, (
+        assert market_state.bond_reserves >= WEI or market_state.bond_reserves == 0, (
             "pricing_models.check_input_assertions: ERROR: "
-            f"expected bond_reserves >= 1e-18 or bond_reserves == 0, not {market_state.bond_reserves}!"
+            f"expected bond_reserves >= {WEI} or bond_reserves == 0, not {market_state.bond_reserves}!"
         )
         assert market_state.share_price >= market_state.init_share_price >= 1, (
             f"pricing_models.check_input_assertions: ERROR: "
@@ -400,9 +409,9 @@ class PricingModel(ABC):
             f"and init_share_price={market_state.init_share_price}!"
         )
         reserves_difference = abs(market_state.share_reserves * market_state.share_price - market_state.bond_reserves)
-        assert reserves_difference < 20_000_000_000, (
+        assert reserves_difference < MAX_RESERVES_DIFFERENCE, (
             "pricing_models.check_input_assertions: ERROR: "
-            f"expected reserves_difference < 10_000_000_000, not {reserves_difference}!"
+            f"expected reserves_difference < {MAX_RESERVES_DIFFERENCE}, not {reserves_difference}!"
         )
         assert 1 >= fee_percent >= 0, (
             "pricing_models.calc_in_given_out: ERROR: " f"expected 1 >= fee_percent >= 0, not {fee_percent}!"

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -348,7 +348,7 @@ class YieldSpacePricingModel(PricingModel):
         total_reserves = Decimal(market_state.share_price) * Decimal(market_state.share_reserves) + Decimal(
             market_state.bond_reserves
         )
-        spot_price = self._calc_spot_price_from_reserves(
+        spot_price = self._calc_spot_price_from_reserves_high_precision(
             market_state,
             time_remaining,
         )
@@ -567,7 +567,7 @@ class YieldSpacePricingModel(PricingModel):
         total_reserves = Decimal(market_state.share_price) * Decimal(market_state.share_reserves) + Decimal(
             market_state.bond_reserves
         )
-        spot_price = self._calc_spot_price_from_reserves(
+        spot_price = self._calc_spot_price_from_reserves_high_precision(
             market_state,
             time_remaining,
         )

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -1,8 +1,9 @@
 """The YieldSpace pricing model."""
 
+from decimal import Decimal
 import logging
-from elfpy.pricing_models.base import PricingModel
 
+from elfpy.pricing_models.base import PricingModel
 from elfpy.types import (
     MarketTradeResult,
     Quantity,
@@ -68,7 +69,7 @@ class YieldSpacePricingModel(PricingModel):
         assert rate >= 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected rate >= 0, not {rate}!"
         assert 1 > time_remaining.normalized_time >= 0, (
             "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"expected 1 > time_remaining >= 0, not {time_remaining.normalied_time}!"
+            f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
         )
         assert time_remaining.stretched_time >= 0, (
             "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
@@ -342,10 +343,12 @@ class YieldSpacePricingModel(PricingModel):
         """
 
         # Calculate some common values up front.
-        time_elapsed = 1 - time_remaining.stretched_time
-        scale = market_state.share_price / market_state.init_share_price
-        total_reserves = market_state.share_price * market_state.share_reserves + market_state.bond_reserves
-        spot_price = self.calc_spot_price_from_reserves(
+        time_elapsed = 1 - Decimal(time_remaining.stretched_time)
+        scale = Decimal(market_state.share_price) / Decimal(market_state.init_share_price)
+        total_reserves = Decimal(market_state.share_price) * Decimal(market_state.share_reserves) + Decimal(
+            market_state.bond_reserves
+        )
+        spot_price = self._calc_spot_price_from_reserves(
             market_state,
             time_remaining,
         )
@@ -354,11 +357,11 @@ class YieldSpacePricingModel(PricingModel):
         # share price:
         #
         # k = (c / μ) * (μ * z)**(1 - t) + (2y + cz)**(1 - t)
-        k = price_utils.calc_k_const(market_state, time_elapsed)
+        k = price_utils.calc_k_const(market_state, time_remaining)
         if out.unit == TokenType.BASE:
-            in_reserves = market_state.bond_reserves + total_reserves
-            out_reserves = market_state.share_reserves
-            d_shares = out.amount / market_state.share_price
+            in_reserves = Decimal(market_state.bond_reserves) + total_reserves
+            out_reserves = Decimal(market_state.share_reserves)
+            d_shares = Decimal(out.amount) / Decimal(market_state.share_price)
 
             # The amount the user pays without fees or slippage is simply the
             # amount of base the user would receive times the inverse of the
@@ -368,7 +371,7 @@ class YieldSpacePricingModel(PricingModel):
             # be the conventional spot price, then we can write this as:
             #
             # without_fee_or_slippage = (1 / p) * c * d_z
-            without_fee_or_slippage = (1 / spot_price) * market_state.share_price * d_shares
+            without_fee_or_slippage = (1 / spot_price) * Decimal(market_state.share_price) * d_shares
 
             # We solve the YieldSpace invariant for the bonds paid to receive
             # the requested amount of base. We set up the invariant where the
@@ -383,18 +386,15 @@ class YieldSpacePricingModel(PricingModel):
             #
             # without_fee = d_y'
             without_fee = (
-                pow(
-                    k - scale * pow((market_state.init_share_price * (out_reserves - d_shares)), time_elapsed),
-                    1 / time_elapsed,
-                )
-                - in_reserves
-            )
+                k - scale * (Decimal(market_state.init_share_price) * (out_reserves - d_shares)) ** time_elapsed
+            ) ** (1 / time_elapsed) - in_reserves
 
             # The fees are calculated as the difference between the bonds paid
             # without slippage and the base received times the fee percentage.
             # This can also be expressed as:
             #
             # fee = ((1 / p) - 1) * φ * c * d_z
+            fee = ((1 / Decimal(spot_price)) - 1) * Decimal(fee_percent) * Decimal(market_state.share_price) * d_shares
             logging.debug(
                 (
                     "fee = ((1 / spot_price) - 1) * fee_percent * share_price * d_shares = "
@@ -404,9 +404,8 @@ class YieldSpacePricingModel(PricingModel):
                 fee_percent,
                 market_state.share_price,
                 d_shares,
-                ((1 / spot_price) - 1) * fee_percent * market_state.share_price * d_shares,
+                fee,
             )
-            fee = ((1 / spot_price) - 1) * fee_percent * market_state.share_price * d_shares
 
             # To get the amount paid with fees, add the fee to the calculation that
             # excluded fees. Adding the fees results in more tokens paid, which
@@ -416,16 +415,16 @@ class YieldSpacePricingModel(PricingModel):
             # Create the user and market trade results.
             user_result = UserTradeResult(
                 d_base=out.amount,
-                d_bonds=-with_fee,
+                d_bonds=float(-with_fee),
             )
             market_result = MarketTradeResult(
                 d_base=-out.amount,
-                d_bonds=with_fee,
+                d_bonds=float(with_fee),
             )
         elif out.unit == TokenType.PT:
-            in_reserves = market_state.share_reserves
-            out_reserves = market_state.bond_reserves + total_reserves
-            d_bonds = out.amount
+            in_reserves = Decimal(market_state.share_reserves)
+            out_reserves = Decimal(market_state.bond_reserves) + total_reserves
+            d_bonds = Decimal(out.amount)
 
             # The amount the user pays without fees or slippage is simply
             # the amount of bonds the user would receive times the spot price of
@@ -451,26 +450,23 @@ class YieldSpacePricingModel(PricingModel):
             #
             # without_fee = d_x'
             without_fee = (
-                (1 / market_state.init_share_price)
-                * pow(
-                    (k - pow(out_reserves - d_bonds, time_elapsed)) / scale,
-                    1 / time_elapsed,
-                )
+                (1 / Decimal(market_state.init_share_price))
+                * ((k - (out_reserves - d_bonds) ** time_elapsed) / scale) ** (1 / time_elapsed)
                 - in_reserves
-            ) * market_state.share_price
+            ) * Decimal(market_state.share_price)
 
             # The fees are calculated as the difference between the bonds
             # received and the base paid without slippage times the fee
             # percentage. This can also be expressed as:
             #
             # fee = (1 - p) * φ * d_y
-            fee = (1 - spot_price) * fee_percent * d_bonds
+            fee = (1 - spot_price) * Decimal(fee_percent) * d_bonds
             logging.debug(
                 ("fee = (1 - spot_price) * fee_percent * d_bonds = (1 - %g) * %g * %g = %g"),
                 spot_price,
                 fee_percent,
                 d_bonds,
-                (1 - spot_price) * fee_percent * d_bonds,
+                fee,
             )
 
             # To get the amount paid with fees, add the fee to the calculation that
@@ -480,11 +476,11 @@ class YieldSpacePricingModel(PricingModel):
 
             # Create the user and market trade results.
             user_result = UserTradeResult(
-                d_base=-with_fee,
+                d_base=float(-with_fee),
                 d_bonds=out.amount,
             )
             market_result = MarketTradeResult(
-                d_base=with_fee,
+                d_base=float(with_fee),
                 d_bonds=-out.amount,
             )
         else:
@@ -497,7 +493,10 @@ class YieldSpacePricingModel(PricingModel):
             user_result=user_result,
             market_result=market_result,
             breakdown=TradeBreakdown(
-                without_fee_or_slippage=without_fee_or_slippage, with_fee=with_fee, without_fee=without_fee, fee=fee
+                without_fee_or_slippage=float(without_fee_or_slippage),
+                with_fee=float(with_fee),
+                without_fee=float(without_fee),
+                fee=float(fee),
             ),
         )
 
@@ -563,10 +562,12 @@ class YieldSpacePricingModel(PricingModel):
         """
 
         # Calculate some common values up front.
-        scale = market_state.share_price / market_state.init_share_price
-        time_elapsed = 1 - time_remaining.stretched_time
-        total_reserves = market_state.share_price * market_state.share_reserves + market_state.bond_reserves
-        spot_price = self.calc_spot_price_from_reserves(
+        scale = Decimal(market_state.share_price) / Decimal(market_state.init_share_price)
+        time_elapsed = 1 - Decimal(time_remaining.stretched_time)
+        total_reserves = Decimal(market_state.share_price) * Decimal(market_state.share_reserves) + Decimal(
+            market_state.bond_reserves
+        )
+        spot_price = self._calc_spot_price_from_reserves(
             market_state,
             time_remaining,
         )
@@ -575,11 +576,11 @@ class YieldSpacePricingModel(PricingModel):
         # share price:
         #
         # k = (c / μ) * (μ * z)**(1 - t) + (2y + cz)**(1 - t)
-        k = price_utils.calc_k_const(market_state, time_elapsed)
+        k = price_utils.calc_k_const(market_state, time_remaining)
         if in_.unit == TokenType.BASE:
-            d_shares = in_.amount / market_state.share_price  # convert from base_asset to z (x=cz)
-            in_reserves = market_state.share_reserves
-            out_reserves = market_state.bond_reserves + total_reserves
+            d_shares = Decimal(in_.amount) / Decimal(market_state.share_price)  # convert from base_asset to z (x=cz)
+            in_reserves = Decimal(market_state.share_reserves)
+            out_reserves = Decimal(market_state.bond_reserves) + total_reserves
 
             # The amount the user would receive without fees or slippage is
             # the amount of base the user pays times inverse of the spot price
@@ -587,7 +588,7 @@ class YieldSpacePricingModel(PricingModel):
             # price, then we can write this as:
             #
             # (1 / p) * c * d_z
-            without_fee_or_slippage = (1 / spot_price) * market_state.share_price * d_shares
+            without_fee_or_slippage = (1 / spot_price) * Decimal(market_state.share_price) * d_shares
 
             # We solve the YieldSpace invariant for the bonds received from
             # paying the specified amount of base. We set up the invariant where
@@ -599,17 +600,16 @@ class YieldSpacePricingModel(PricingModel):
             # without including fees:
             #
             # d_y' = 2y + cz - (k - (c / μ) * (μ * (z + d_z))**(1 - t))**(1 / (1 - t))
-            without_fee = out_reserves - pow(
-                k - scale * pow(market_state.init_share_price * (in_reserves + d_shares), time_elapsed),
-                1 / time_elapsed,
-            )
+            without_fee = out_reserves - (
+                k - scale * (Decimal(market_state.init_share_price) * (in_reserves + d_shares)) ** time_elapsed
+            ) ** (1 / time_elapsed)
 
             # The fees are calculated as the difference between the bonds
             # received without slippage and the base paid times the fee
             # percentage. This can also be expressed as:
             #
             # ((1 / p) - 1) * φ * c * d_z
-            fee = ((1 / spot_price) - 1) * fee_percent * market_state.share_price * d_shares
+            fee = ((1 / spot_price) - 1) * Decimal(fee_percent) * Decimal(market_state.share_price) * d_shares
 
             # To get the amount paid with fees, subtract the fee from the
             # calculation that excluded fees. Subtracting the fees results in less
@@ -619,16 +619,16 @@ class YieldSpacePricingModel(PricingModel):
             # Create the user and market trade results.
             user_result = UserTradeResult(
                 d_base=-in_.amount,
-                d_bonds=with_fee,
+                d_bonds=float(with_fee),
             )
             market_result = MarketTradeResult(
                 d_base=in_.amount,
-                d_bonds=-with_fee,
+                d_bonds=float(-with_fee),
             )
         elif in_.unit == TokenType.PT:
-            d_bonds = in_.amount
-            in_reserves = market_state.bond_reserves + total_reserves
-            out_reserves = market_state.share_reserves
+            d_bonds = Decimal(in_.amount)
+            in_reserves = Decimal(market_state.bond_reserves) + total_reserves
+            out_reserves = Decimal(market_state.share_reserves)
 
             # The amount the user would receive without fees or slippage is the
             # amount of bonds the user pays times the spot price of base in
@@ -654,17 +654,17 @@ class YieldSpacePricingModel(PricingModel):
             #
             # without_fee = d_x'
             without_fee = (
-                market_state.share_reserves
-                - (1 / market_state.init_share_price)
+                Decimal(market_state.share_reserves)
+                - (1 / Decimal(market_state.init_share_price))
                 * ((k - (in_reserves + d_bonds) ** time_elapsed) / scale) ** (1 / time_elapsed)
-            ) * market_state.share_price
+            ) * Decimal(market_state.share_price)
 
             # The fees are calculated as the difference between the bonds paid
             # and the base received without slippage times the fee percentage.
             # This can also be expressed as:
             #
             # fee = (1 - p) * φ * d_y
-            fee = (1 - spot_price) * fee_percent * d_bonds
+            fee = (1 - spot_price) * Decimal(fee_percent) * d_bonds
             with_fee = without_fee - fee
 
             # To get the amount paid with fees, subtract the fee from the
@@ -674,11 +674,11 @@ class YieldSpacePricingModel(PricingModel):
 
             # Create the user and market trade results.
             user_result = UserTradeResult(
-                d_base=with_fee,
+                d_base=float(with_fee),
                 d_bonds=-in_.amount,
             )
             market_result = MarketTradeResult(
-                d_base=-with_fee,
+                d_base=float(-with_fee),
                 d_bonds=in_.amount,
             )
         else:
@@ -691,6 +691,9 @@ class YieldSpacePricingModel(PricingModel):
             user_result=user_result,
             market_result=market_result,
             breakdown=TradeBreakdown(
-                without_fee_or_slippage=without_fee_or_slippage, with_fee=with_fee, without_fee=without_fee, fee=fee
+                without_fee_or_slippage=float(without_fee_or_slippage),
+                with_fee=float(with_fee),
+                without_fee=float(without_fee),
+                fee=float(fee),
             ),
         )

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -10,7 +10,16 @@ import elfpy.utils.time as time_utils
 
 if TYPE_CHECKING:
     from elfpy.agent import Agent
-    from typing import Any
+
+# This is the minimum allowed value to be passed into calculations to avoid
+# problems with sign flips that occur when the floating point range is exceeded.
+WEI = 1e-18
+
+# The maximum allowed difference between the base reserves and bond reserves.
+# This value was calculated using trial and error and is close to the maximum
+# difference between the reserves that will not result in a sign flip when a
+# small trade is put on.
+MAX_RESERVES_DIFFERENCE = 2e10
 
 
 class TokenType(Enum):

--- a/src/elfpy/utils/price.py
+++ b/src/elfpy/utils/price.py
@@ -1,7 +1,8 @@
 """Utilities for price calculations"""
 
 
-from __future__ import annotations  # types will be strings by default in 3.11
+from __future__ import annotations
+from decimal import Decimal  # types will be strings by default in 3.11
 from typing import TYPE_CHECKING
 
 from elfpy.types import MarketState, StretchedTime
@@ -127,8 +128,7 @@ def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
     return 1 / (1 + apr * time_remaining.normalized_time)  # price = 1 / (1 + r * t)
 
 
-# TODO: This should be updated to use StretchedTime.
-def calc_k_const(market_state: MarketState, time_elapsed):
+def calc_k_const(market_state: MarketState, time_remaining: StretchedTime):
     """
     Returns the 'k' constant variable for trade mathematics
 
@@ -136,16 +136,20 @@ def calc_k_const(market_state: MarketState, time_elapsed):
     ---------
     market_state : MarketState
         The state of the AMM
-    time_elapsed : float
-        Amount of time that has elapsed in the current market, in yearfracs
+    time_remaining : StretchedTime
+        Amount of time that remains in the current market
 
     Returns
     -------
-    float
+    Decimal
         'k' constant used for trade mathematics, calculated from the provided parameters
     """
-    scale = market_state.share_price / market_state.init_share_price
-    total_reserves = market_state.bond_reserves + market_state.share_price * market_state.share_reserves
-    return scale * (market_state.init_share_price * market_state.share_reserves) ** (time_elapsed) + (
-        market_state.bond_reserves + total_reserves
-    ) ** (time_elapsed)
+    scale = Decimal(market_state.share_price) / Decimal(market_state.init_share_price)
+    total_reserves = Decimal(market_state.bond_reserves) + Decimal(market_state.share_price) * Decimal(
+        market_state.share_reserves
+    )
+    time_elapsed = Decimal(1) - Decimal(time_remaining.stretched_time)
+    return (
+        scale * (Decimal(market_state.init_share_price) * Decimal(market_state.share_reserves)) ** time_elapsed
+        + (Decimal(market_state.bond_reserves) + Decimal(total_reserves)) ** time_elapsed
+    )

--- a/src/elfpy/utils/price.py
+++ b/src/elfpy/utils/price.py
@@ -1,8 +1,8 @@
 """Utilities for price calculations"""
 
 
-from __future__ import annotations
-from decimal import Decimal  # types will be strings by default in 3.11
+from __future__ import annotations  # types will be strings by default in 3.11
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from elfpy.types import MarketState, StretchedTime
@@ -128,7 +128,7 @@ def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
     return 1 / (1 + apr * time_remaining.normalized_time)  # price = 1 / (1 + r * t)
 
 
-def calc_k_const(market_state: MarketState, time_remaining: StretchedTime):
+def calc_k_const(market_state: MarketState, time_remaining: StretchedTime) -> Decimal:
     """
     Returns the 'k' constant variable for trade mathematics
 

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -757,7 +757,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 market_state = MarketState(
                     share_reserves=10_000_000_000,
                     bond_reserves=1,
-                    share_price=1,
+                    share_price=2,
                     init_share_price=1,
                 )
                 fee_percent = 0.1
@@ -775,7 +775,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 market_state = MarketState(
                     share_reserves=1,
                     bond_reserves=10_000_000_000,
-                    share_price=1.5,
+                    share_price=2,
                     init_share_price=1.2,
                 )
                 fee_percent = 0.1
@@ -964,14 +964,50 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=0.5e-18, unit=TokenType.BASE),
+                out=Quantity(amount=0.5e-18, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
                     share_price=0,
                     init_share_price=1.5,
                 ),
-                fee_percent=0.1,
+                fee_percent=0.01,
+                time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcInGivenOutFailure(
+                out=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=0.5e-18,
+                    bond_reserves=1_000_000,
+                    share_price=0,
+                    init_share_price=1.5,
+                ),
+                fee_percent=0.01,
+                time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcInGivenOutFailure(
+                out=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=100_000,
+                    bond_reserves=0.5e-18,
+                    share_price=0,
+                    init_share_price=1.5,
+                ),
+                fee_percent=0.01,
+                time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcInGivenOutFailure(
+                out=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=30_000_000_000,
+                    bond_reserves=1,
+                    share_price=0,
+                    init_share_price=1.5,
+                ),
+                fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
                 exception_type=AssertionError,
             ),

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -9,6 +9,8 @@ Testing for the calc_in_given_out of the pricing models.
 # pylint: disable=duplicate-code
 
 from dataclasses import dataclass
+import decimal
+from typing import Type
 import unittest
 import numpy as np
 
@@ -50,6 +52,7 @@ class TestCaseCalcInGivenOutFailure:
     market_state: MarketState
     fee_percent: float
     time_remaining: StretchedTime
+    exception_type: Type[Exception]
 
     __test__ = False  # pytest: don't test this class
 
@@ -756,6 +759,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=0, unit=TokenType.PT),
@@ -767,6 +771,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -778,6 +783,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -789,6 +795,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -800,6 +807,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -811,6 +819,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=-1,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -822,6 +831,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=1.1,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -833,6 +843,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=1.1,
                 time_remaining=StretchedTime(days=-91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -844,6 +855,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.1,
                 time_remaining=StretchedTime(days=365, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -855,6 +867,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.1,
                 time_remaining=StretchedTime(days=500, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=10_000_000, unit=TokenType.BASE),
@@ -866,6 +879,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.1,
                 time_remaining=StretchedTime(days=92.5, time_stretch=1),
+                exception_type=decimal.InvalidOperation,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.BASE),
@@ -877,6 +891,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.1,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.BASE),
@@ -888,6 +903,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.1,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.BASE),
@@ -899,14 +915,15 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 fee_percent=0.1,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
         ]
 
-        # Iterate over all of the test cases and verify that the pricing model
-        # raises an AssertionError for each test case.
+        # Verify that the pricing model raises the expected exception type for
+        # each test case.
         for test_case in test_cases:
             for pricing_model in pricing_models:
-                with self.assertRaises(AssertionError):
+                with self.assertRaises(test_case.exception_type):
                     pricing_model.check_input_assertions(
                         quantity=test_case.out,
                         market_state=test_case.market_state,

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -751,9 +751,9 @@ class TestCalcInGivenOut(unittest.TestCase):
         pricing_models: list[PricingModel] = [YieldSpacePricingModel(), HyperdrivePricingModel()]
 
         for pricing_model in pricing_models:
-            for x in [1 / 10**x for x in range(0, 19)]:
+            for trade_amount in [1 / 10**x for x in range(0, 19)]:
                 # out is in base, in is in bonds
-                trade_quantity = Quantity(amount=x, unit=TokenType.BASE)
+                trade_quantity = Quantity(amount=trade_amount, unit=TokenType.BASE)
                 market_state = MarketState(
                     share_reserves=10_000_000_000,
                     bond_reserves=1,
@@ -771,7 +771,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 self.assertGreater(trade_result.breakdown.with_fee, 0.0)
 
                 # out is in bonds, in is in base
-                trade_quantity = Quantity(amount=x, unit=TokenType.PT)
+                trade_quantity = Quantity(amount=trade_amount, unit=TokenType.PT)
                 market_state = MarketState(
                     share_reserves=1,
                     bond_reserves=10_000_000_000,

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -990,9 +990,9 @@ class TestCalcOutGivenIn(unittest.TestCase):
         pricing_models: list[PricingModel] = [YieldSpacePricingModel(), HyperdrivePricingModel()]
 
         for pricing_model in pricing_models:
-            for x in [1 / 10**x for x in range(0, 19)]:
+            for trade_amount in [1 / 10**x for x in range(0, 19)]:
                 # in is in base, out is in bonds
-                trade_quantity = Quantity(amount=x, unit=TokenType.BASE)
+                trade_quantity = Quantity(amount=trade_amount, unit=TokenType.BASE)
                 market_state = MarketState(
                     share_reserves=1,
                     bond_reserves=20_000_000_000,
@@ -1010,7 +1010,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 self.assertGreater(trade_result.breakdown.with_fee, 0.0)
 
                 # in is in bonds, out is in base
-                trade_quantity = Quantity(amount=x, unit=TokenType.PT)
+                trade_quantity = Quantity(amount=trade_amount, unit=TokenType.PT)
                 market_state = MarketState(
                     share_reserves=10_000_000_000,
                     bond_reserves=1,

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -9,6 +9,8 @@ Testing for the calc_out_given_in of the pricing models.
 # pylint: disable=duplicate-code
 
 from dataclasses import dataclass
+import decimal
+from typing import Type
 import unittest
 import numpy as np
 
@@ -38,6 +40,7 @@ class TestCaseCalcOutGivenInFailure:
     market_state: MarketState
     fee_percent: float
     time_remaining: StretchedTime
+    exception_type: Type[Exception]
 
     __test__ = False  # pytest: don't test this class
 
@@ -995,6 +998,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=0, unit=TokenType.PT),
@@ -1006,6 +1010,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1017,6 +1022,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1028,6 +1034,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1039,6 +1046,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=-1,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1050,6 +1058,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=1.1,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1061,6 +1070,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=-91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1072,6 +1082,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=365, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1083,6 +1094,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=500, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=10_000_000, unit=TokenType.PT),
@@ -1094,6 +1106,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=decimal.InvalidOperation,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1105,6 +1118,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1116,6 +1130,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1127,14 +1142,15 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 fee_percent=0.01,
                 time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
             ),
         ]
 
-        # Iterate over all of the test cases and verify that the pricing model
-        # raises an AssertionError for each test case.
+        # Verify that the pricing model raises the expected exception type for
+        # each test case.
         for test_case in test_cases:
             for pricing_model in pricing_models:
-                with self.assertRaises(AssertionError):
+                with self.assertRaises(test_case.exception_type):
                     pricing_model.check_input_assertions(
                         quantity=test_case.in_,
                         market_state=test_case.market_state,

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -995,7 +995,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 trade_quantity = Quantity(amount=x, unit=TokenType.BASE)
                 market_state = MarketState(
                     share_reserves=1,
-                    bond_reserves=10_000_000_000,
+                    bond_reserves=20_000_000_000,
                     share_price=1,
                     init_share_price=1,
                 )
@@ -1014,7 +1014,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 market_state = MarketState(
                     share_reserves=10_000_000_000,
                     bond_reserves=1,
-                    share_price=1.5,
+                    share_price=2,
                     init_share_price=1.2,
                 )
                 fee_percent = 0.1
@@ -1195,6 +1195,42 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
+                    share_price=0,
+                    init_share_price=1.5,
+                ),
+                fee_percent=0.01,
+                time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcOutGivenInFailure(
+                in_=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=0.5e-18,
+                    bond_reserves=1_000_000,
+                    share_price=0,
+                    init_share_price=1.5,
+                ),
+                fee_percent=0.01,
+                time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcOutGivenInFailure(
+                in_=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=100_000,
+                    bond_reserves=0.5e-18,
+                    share_price=0,
+                    init_share_price=1.5,
+                ),
+                fee_percent=0.01,
+                time_remaining=StretchedTime(days=91.25, time_stretch=1),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcOutGivenInFailure(
+                in_=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=30_000_000_000,
+                    bond_reserves=1,
                     share_price=0,
                     init_share_price=1.5,
                 ),

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1164,3 +1164,48 @@ class TestCalcOutGivenIn(unittest.TestCase):
                         time_remaining=test_case.time_remaining,
                     )
                     pricing_model.check_output_assertions(trade_result=trade_result)
+
+    def test_precision(self):
+        pricing_model: PricingModel = YieldSpacePricingModel()
+        trade_quantity = Quantity(amount=3.9782736063866743e-10, unit=TokenType.PT)
+        market_state = MarketState(
+            share_reserves=6886430.051772878,
+            bond_reserves=1861020.383125815,
+            base_buffer=9937.310853662613,
+            bond_buffer=1.0024308644783892,
+            lp_reserves=14035648.707374929,
+            share_price=1.0393188529045994,
+            init_share_price=1.038436427353945,
+        )
+        fee_percent = 0.18814394910904456
+        time_remaining = StretchedTime(days=365, time_stretch=16.468271036923056)
+        trade_result = pricing_model.calc_out_given_in(
+            in_=trade_quantity,
+            market_state=market_state,
+            fee_percent=fee_percent,
+            time_remaining=time_remaining,
+        )
+        self.assertGreaterEqual(trade_result.breakdown.with_fee, 0.0)
+
+        for x in [x / 10 ** (x + 1) for x in range(0, 20)]:
+            trade_quantity = Quantity(amount=x, unit=TokenType.PT)
+            market_state = MarketState(
+                share_reserves=1_000_000,
+                bond_reserves=1_000_000,
+                base_buffer=10_000,
+                bond_buffer=10_000,
+                share_price=1.5,
+                init_share_price=1.2,
+            )
+            fee_percent = 0.1
+            time_remaining = StretchedTime(days=365, time_stretch=pricing_model.calc_time_stretch(0.05))
+            trade_result = pricing_model.calc_out_given_in(
+                in_=trade_quantity,
+                market_state=market_state,
+                fee_percent=fee_percent,
+                time_remaining=time_remaining,
+            )
+            print(f"\nquantity = {x}\nwith_fee = {trade_result.breakdown.with_fee}")
+
+        # FIXME: Make a bunch of random (but valid) trades.
+        # trade_quantity = Quantity(amount=rng.uniform(low=0)

--- a/tests/utils/test_price_utils.py
+++ b/tests/utils/test_price_utils.py
@@ -14,6 +14,7 @@ from elfpy.markets import Market
 from elfpy.types import MarketState, StretchedTime
 from elfpy.utils import price as price_utils
 from elfpy.utils import sim_utils
+from elfpy.utils.time import time_to_days_remaining
 
 
 class BasePriceTest(unittest.TestCase):
@@ -524,19 +525,25 @@ class BasePriceTest(unittest.TestCase):
 
                 # Check that test case throws the expected error
                 with self.assertRaises(test_case["expected_result"]):
-                    k = price_utils.calc_k_const(
-                        market_state=test_case["market_state"],
-                        time_elapsed=test_case["time_elapsed"],
+                    k = float(
+                        price_utils.calc_k_const(
+                            market_state=test_case["market_state"],
+                            time_remaining=StretchedTime(
+                                days=time_to_days_remaining(1 - test_case["time_elapsed"]), time_stretch=1
+                            ),
+                        )
                     )
 
             # If test was not supposed to fail, continue normal execution
             else:
-
-                k = price_utils.calc_k_const(
-                    market_state=test_case["market_state"],
-                    time_elapsed=test_case["time_elapsed"],
+                k = float(
+                    price_utils.calc_k_const(
+                        market_state=test_case["market_state"],
+                        time_remaining=StretchedTime(
+                            days=time_to_days_remaining(1 - test_case["time_elapsed"]), time_stretch=1
+                        ),
+                    )
                 )
-
                 np.testing.assert_almost_equal(k, test_case["expected_result"], err_msg="unexpected k")
 
 


### PR DESCRIPTION
Prior to this PR, the pricing model performed all computations using floating point arithmetic. Since floating point numbers have a maximum range of 18 decimals, this led to situations in which pricing model calculations would be rounded up. These numerical errors would build up over multiple arithmetic operations, which led to sign flip errors.

The resolution to these errors is to add a minimum to input trade quantities, maximums differences to the reserves, and use the `Decimal` module for all calculations within the pricing model (while still accepting float inputs and returning float outputs).