### PR TITLE
test python 3.11 and fix Config to work with it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -22,6 +22,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install black~=22.0 pylint pytest nose
+          python -m pip install stochastic --ignore-requires-python
           python -m pip install -r requirements.txt
           python -m pip install .
       - name: Running package tests

--- a/src/elfpy/utils/config.py
+++ b/src/elfpy/utils/config.py
@@ -90,9 +90,9 @@ class SimulatorConfig:
 class Config:
     """Data object for storing user simulation config parameters"""
 
-    market: MarketConfig = MarketConfig()
-    amm: AMMConfig = AMMConfig()
-    simulator: SimulatorConfig = SimulatorConfig()
+    market: MarketConfig = field(default_factory=MarketConfig)
+    amm: AMMConfig = field(default_factory=AMMConfig)
+    simulator: SimulatorConfig = field(default_factory=SimulatorConfig)
 
     def __getitem__(self, key):
         return getattr(self, key)


### PR DESCRIPTION
without this my pytest errors as follows:
```
================================================================================= short test summary info =================================================================================
ERROR tests/test_logging.py - ValueError: mutable default <class 'elfpy.utils.config.MarketConfig'> for field market is not allowed: use default_factory
ERROR tests/test_sim.py - ValueError: mutable default <class 'elfpy.utils.config.MarketConfig'> for field market is not allowed: use default_factory
ERROR tests/test_trade.py - ValueError: mutable default <class 'elfpy.utils.config.MarketConfig'> for field market is not allowed: use default_factory
ERROR tests/utils/test_parse_config.py - ValueError: mutable default <class 'elfpy.utils.config.MarketConfig'> for field market is not allowed: use default_factory
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
==================================================================================== 4 errors in 0.55s ====================================================================================
```