### PR TITLE
fix yieldspace tests

### DIFF
--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -581,7 +581,6 @@ class YieldSpacePricingModel(PricingModel):
             time_remaining,
         )
         in_amount = Decimal(in_.amount)
-        share_price = Decimal(market_state.init_share_price)
         _fee_percent = Decimal(fee_percent)
 
         # We precompute the YieldSpace constant k using the current reserves and
@@ -593,7 +592,6 @@ class YieldSpacePricingModel(PricingModel):
             d_shares = in_amount / share_price  # convert from base_asset to z (x=cz)
             in_reserves = share_reserves
             out_reserves = bond_reserves + total_reserves
-
             # The amount the user would receive without fees or slippage is
             # the amount of base the user pays times inverse of the spot price
             # of base in terms of bonds. If we let p be the conventional spot
@@ -612,9 +610,9 @@ class YieldSpacePricingModel(PricingModel):
             # without including fees:
             #
             # d_y' = 2y + cz - (k - (c / mu) * (mu * (z + d_z))**(1 - tau))**(1 / (1 - tau))
-            without_fee = out_reserves - (k - scale * (share_price * (in_reserves + d_shares)) ** time_elapsed) ** (
-                1 / time_elapsed
-            )
+            without_fee = out_reserves - (
+                k - scale * (init_share_price * (in_reserves + d_shares)) ** time_elapsed
+            ) ** (1 / time_elapsed)
 
             # The fees are calculated as the difference between the bonds
             # received without slippage and the base paid times the fee
@@ -667,7 +665,7 @@ class YieldSpacePricingModel(PricingModel):
             # without_fee = d_x'
             without_fee = (
                 share_reserves
-                - (1 / share_price) * ((k - (in_reserves + d_bonds) ** time_elapsed) / scale) ** (1 / time_elapsed)
+                - (1 / init_share_price) * ((k - (in_reserves + d_bonds) ** time_elapsed) / scale) ** (1 / time_elapsed)
             ) * share_price
 
             # The fees are calculated as the difference between the bonds paid

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1281,8 +1281,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
             for pricing_model in pricing_models:
                 model_name = pricing_model.model_name()
                 model_type = pricing_model.model_type()
-                if model_type == "yieldspace":
-                    break
+
                 time_stretch = pricing_model.calc_time_stretch(test_case.time_stretch_apy)
 
                 expected_result = results_by_model[model_type]
@@ -1297,24 +1296,24 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 np.testing.assert_almost_equal(
                     trade_result.breakdown.without_fee_or_slippage,
                     expected_result.without_fee_or_slippage,
-                    err_msg=f"test {test_number + 1} unexpected without_fee_or_slippage",
+                    err_msg=f"{model_type} test {test_number + 1} unexpected without_fee_or_slippage",
                 )
                 np.testing.assert_almost_equal(
                     trade_result.breakdown.without_fee,
                     expected_result.without_fee,
-                    err_msg=f"test {test_number + 1} unexpected without_fee",
+                    err_msg=f"{model_type} test {test_number + 1} unexpected without_fee",
                 )
                 model_name = pricing_model.model_name()
                 if model_type in {"yieldspace", "hyperdrive"}:
                     np.testing.assert_almost_equal(
                         trade_result.breakdown.fee,
                         expected_result.fee,
-                        err_msg=f"test {test_number + 1} unexpected fee",
+                        err_msg=f"{model_type} test {test_number + 1} unexpected fee",
                     )
                     np.testing.assert_almost_equal(
                         trade_result.breakdown.with_fee,
                         expected_result.with_fee,
-                        err_msg=f"test {test_number + 1} unexpected with_fee",
+                        err_msg=f"{model_type} test {test_number + 1} unexpected with_fee",
                     )
                 else:
                     raise AssertionError(f'Expected model_name to be "YieldSpace", not {model_name}')


### PR DESCRIPTION
the yieldspace calc out given in tests were not running because the file name didn't start with 'test'.  This means that changes in #136 that broke tests weren't caught.  They showed as broken in #135 when the filename was changed.  This PR fixes the equations so the tests pass.