### PR TITLE
update short logic to account for margin interest

### DIFF
--- a/examples/example_main.py
+++ b/examples/example_main.py
@@ -48,7 +48,9 @@ class CustomShorter(Agent):
                 if has_opened_short:
                     action_list.append(
                         self.create_agent_action(
-                            action_type=MarketActionType.CLOSE_SHORT, trade_amount=self.pt_to_short
+                            action_type=MarketActionType.CLOSE_SHORT,
+                            trade_amount=self.pt_to_short,
+                            open_share_price=1.0,
                         )
                     )
         return action_list

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -290,7 +290,7 @@ class Agent:
                     # if the balance is positive, we are opening a short, therefore do a weighted
                     # mean for the open share price.  this covers an edge case where two shorts are
                     # opened for the same account in the same block.  if the balance is negative, we
-                    # don't want to updat the open_short_price
+                    # don't want to update the open_short_price
                     if short.balance > 0:
                         self.wallet.shorts[mint_time].open_share_price = (
                             short.open_share_price * short.balance + old_share_price * old_balance

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -106,8 +106,11 @@ class MarketAction:
     # these two variables are required to be set by the strategy
     action_type: MarketActionType
     trade_amount: float
+    # TODO: pass in the entire wallet instead of wallet_address and the open_share_price
     # wallet_address is always set automatically by the basic agent class
     wallet_address: int
+    # the share price when a short was created
+    open_share_price: float
     # mint time is set only for trades that act on existing positions (close long or close short)
     mint_time: float = 0
 

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -110,7 +110,7 @@ class MarketAction:
     # wallet_address is always set automatically by the basic agent class
     wallet_address: int
     # the share price when a short was created
-    open_share_price: float
+    open_share_price: float = 1
     # mint time is set only for trades that act on existing positions (close long or close short)
     mint_time: float = 0
 

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -41,7 +41,7 @@ class Short:
     open_share_price: float
 
     def __str__(self):
-        return f"Short(balance: {self.balance}, margin: {self.open_share_price})"
+        return f"Short(balance: {self.balance}, open_share_price: {self.open_share_price})"
 
 
 @dataclass(frozen=False)

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -33,15 +33,15 @@ class Short:
     ----------
     balance : float
         The amount of bonds that the position is short.
-    margin : float
-        The amount of margin the short position has.
+    open_share_price: float
+        The share price at the time the short was opened.
     """
 
     balance: float
-    margin: float
+    open_share_price: float
 
     def __str__(self):
-        return f"Short(balance: {self.balance}, margin: {self.margin})"
+        return f"Short(balance: {self.balance}, margin: {self.open_share_price})"
 
 
 @dataclass(frozen=False)
@@ -134,7 +134,7 @@ class Wallet:
         shorts_value = 0
         for (mint_time, short) in self.shorts.items():
             base = (
-                market.close_short(self.address, short.balance, mint_time)[1].base
+                market.close_short(self.address, short.open_share_price, short.balance, mint_time)[1].base
                 if short.balance > 0 and share_reserves
                 else 0.0
             )

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -120,11 +120,13 @@ class BaseMarketTest(unittest.TestCase):
         amount_of_bonds_sold = agent_deltas.shorts[0].balance
         # sell those bonds to close the short (partial is the amount of the short to close, 1.0 by default)
         trade_amount = amount_of_bonds_sold * partial
+        mint_time = 0
         if tick_time:
             simulator.market.tick(simulator.market_step_size())
         market_deltas, agent_deltas = simulator.market.close_short(
-            mint_time=0,
+            mint_time=mint_time,
             wallet_address=1,
+            open_share_price=agent.wallet.shorts[mint_time].open_share_price,
             trade_amount=trade_amount,  # in bonds: that's the thing you owe, and need to buy back
         )
         actual_deltas = Deltas(market_deltas=market_deltas, agent_deltas=agent_deltas)
@@ -233,7 +235,7 @@ class MarketTestsOneFunction(BaseMarketTest):
             # margin is the amount of base asset that is in the agent's margin account
             # it is composed of two parts: proceeds from sale of bonds (d_base)
             # and the additional base deposited by the agent to cover the worst case scenario (max_loss)
-            shorts={0: Short(balance=d_bonds, margin=d_margin)},
+            shorts={0: Short(balance=d_bonds, open_share_price=1)},
             fees_paid=fees_paid,
         )
         expected_deltas = Deltas(market_deltas=expected_market_deltas, agent_deltas=expected_agent_deltas)
@@ -262,7 +264,7 @@ class MarketTestsOneFunction(BaseMarketTest):
             address=1,
             base=d_base_agent,  # base asset increases because agent is getting base back to close his bond position
             shorts={
-                0: Short(balance=-d_bonds, margin=-d_margin)
+                0: Short(balance=-d_bonds, open_share_price=0)
             },  # shorts decrease by the amount of bonds sold to close the position
             fees_paid=fees_paid,
         )
@@ -292,7 +294,7 @@ class MarketTestsOneFunction(BaseMarketTest):
             address=1,
             base=d_base_agent,  # base asset increases because agent is getting base back to close his bond position
             shorts={
-                0: Short(balance=-d_bonds, margin=-d_margin)
+                0: Short(balance=-d_bonds, open_share_price=0)
             },  # shorts decrease by the amount of bonds sold to close the position
             fees_paid=fees_paid,
         )
@@ -325,7 +327,7 @@ class MarketTestsOneFunction(BaseMarketTest):
             address=1,
             base=d_base_agent,  # base asset increases because agent is getting base back to close his bond position
             shorts={
-                0: Short(balance=-d_bonds, margin=-d_margin)
+                0: Short(balance=-d_bonds, open_share_price=0)
             },  # shorts decrease by the amount of bonds sold to close the position
             fees_paid=fees_paid,
         )
@@ -358,7 +360,7 @@ class MarketTestsOneFunction(BaseMarketTest):
             address=1,
             base=d_base_agent,  # base asset increases because agent is getting base back to close his bond position
             shorts={
-                0: Short(balance=-d_bonds, margin=-d_margin)
+                0: Short(balance=-d_bonds, open_share_price=0)
             },  # shorts decrease by the amount of bonds sold to close the position
             fees_paid=fees_paid,
         )

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -126,7 +126,7 @@ class BaseMarketTest(unittest.TestCase):
         market_deltas, agent_deltas = simulator.market.close_short(
             mint_time=mint_time,
             wallet_address=1,
-            open_share_price=agent.wallet.shorts[mint_time].open_share_price,
+            open_share_price=agent_deltas.shorts[mint_time].open_share_price,
             trade_amount=trade_amount,  # in bonds: that's the thing you owe, and need to buy back
         )
         actual_deltas = Deltas(market_deltas=market_deltas, agent_deltas=agent_deltas)
@@ -219,6 +219,7 @@ class MarketTestsOneFunction(BaseMarketTest):
         d_base = trade_result  # proceeds from your sale of bonds, go into your margin account so you don't rug
         d_bonds = 100
         d_margin = d_base + max_loss
+        open_share_price = 1.0086194128439765
 
         expected_market_deltas = MarketDeltas(
             d_base_asset=-d_base,  # base asset decreases because agent is buying base from market to sell bonds
@@ -235,7 +236,7 @@ class MarketTestsOneFunction(BaseMarketTest):
             # margin is the amount of base asset that is in the agent's margin account
             # it is composed of two parts: proceeds from sale of bonds (d_base)
             # and the additional base deposited by the agent to cover the worst case scenario (max_loss)
-            shorts={0: Short(balance=d_bonds, open_share_price=1)},
+            shorts={0: Short(balance=d_bonds, open_share_price=open_share_price)},
             fees_paid=fees_paid,
         )
         expected_deltas = Deltas(market_deltas=expected_market_deltas, agent_deltas=expected_agent_deltas)

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -218,7 +218,6 @@ class MarketTestsOneFunction(BaseMarketTest):
         # assign to appropriate token, for readability using absolute values, assigning +/- below
         d_base = trade_result  # proceeds from your sale of bonds, go into your margin account so you don't rug
         d_bonds = 100
-        d_margin = d_base + max_loss
         open_share_price = 1.0086194128439765
 
         expected_market_deltas = MarketDeltas(
@@ -250,7 +249,6 @@ class MarketTestsOneFunction(BaseMarketTest):
         # assign to appropriate token: for readability using absolute values, assigning +/- below
         d_base_market = trade_result_close_short_in_base  # result of the second trade
         d_bonds = 100
-        d_margin = d_bonds  # reducing the margin in your account by the total amount put up (covering worst case)
         d_base_agent = 100 - trade_result_close_short_in_base  # remaining margin after closing the position
         fees_paid = 0.12178619756427611  # taken from pricing model output, not tested here
         expected_market_deltas = MarketDeltas(
@@ -280,7 +278,6 @@ class MarketTestsOneFunction(BaseMarketTest):
         # assign to appropriate token: for readability using absolute values, assigning +/- below
         d_base_market = trade_result_close_short_in_base  # result of the second trade
         d_bonds = 100
-        d_margin = d_bonds  # reducing the margin in your account by the total amount put up (covering worst case)
         d_base_agent = 100 - trade_result_close_short_in_base  # remaining margin after closing the position
         fees_paid = 0.12133788526308154  # taken from pricing model output, not tested here
         expected_market_deltas = MarketDeltas(
@@ -314,7 +311,6 @@ class MarketTestsOneFunction(BaseMarketTest):
         # calculate the improvement in your max loss (worst case scenario - cost to close the short)
         d_max_loss = d_worst_case_scenario - trade_result_close_short_in_base
         d_base_agent = d_max_loss  # get back the improvement in your max loss
-        d_margin = d_bonds  # reducing the margin in your account by the trade face value (covering worst case)
         fees_paid = 0.060893098782138055  # taken from pricing model output, not tested here
         expected_market_deltas = MarketDeltas(
             d_base_asset=d_base_market,  # base asset decreases because agent is buying base from market to sell bonds
@@ -347,7 +343,6 @@ class MarketTestsOneFunction(BaseMarketTest):
         # calculate the improvement in your max loss (worst case scenario - cost to close the short)
         d_max_loss = d_worst_case_scenario - trade_result_close_short_in_base
         d_base_agent = d_max_loss  # get back the improvement in your max loss
-        d_margin = d_bonds  # reducing the margin in your account by the trade face value (covering worst case)
         fees_paid = 0.06066894263154077  # taken from pricing model output, not tested here
         expected_market_deltas = MarketDeltas(
             d_base_asset=d_base_market,  # base asset decreases because agent is buying base from market to sell bonds


### PR DESCRIPTION
updates the logic and accounting for shorts to properly account for the interest earned on the margin portion of the short.  we are storing the open share price (`c0` in the math) to mirror the accounting used in the smart contracts.