### PR TITLE
check for available shares instead of bonds for get_max_short

### DIFF
--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -469,8 +469,8 @@ class PricingModel(ABC):
         float
             The maximum amount of bonds that can be shorted.
         """
-        available_bonds = market_state.bond_reserves - market_state.bond_buffer
-        if available_bonds <= 0:
+        available_shares = market_state.share_reserves - market_state.base_buffer / market_state.share_price
+        if available_shares <= 0:
             return 0, 0
 
         last_maybe_max_short = 0, 0
@@ -480,7 +480,7 @@ class PricingModel(ABC):
             try:
                 # Compute the amount of base returned by selling the specified
                 # amount of bonds.
-                maybe_max_short_bonds = available_bonds * bond_percent
+                maybe_max_short_bonds = available_shares / market_state.share_price * bond_percent
                 trade_result = self.calc_out_given_in(
                     in_=Quantity(amount=maybe_max_short_bonds, unit=TokenType.PT),
                     market_state=market_state,

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -465,8 +465,8 @@ class PricingModel(ABC):
         float
             The maximum amount of bonds that can be shorted.
         """
-        available_shares = market_state.share_reserves - market_state.base_buffer / market_state.share_price
-        if available_shares <= 0:
+        available_bonds = market_state.bond_reserves - market_state.bond_buffer
+        if available_bonds <= 0:
             return 0, 0
 
         last_maybe_max_short = 0, 0
@@ -476,7 +476,7 @@ class PricingModel(ABC):
             try:
                 # Compute the amount of base returned by selling the specified
                 # amount of bonds.
-                maybe_max_short_bonds = available_shares / market_state.share_price * bond_percent
+                maybe_max_short_bonds = available_bonds * bond_percent
                 trade_result = self.calc_out_given_in(
                     in_=Quantity(amount=maybe_max_short_bonds, unit=TokenType.PT),
                     market_state=market_state,

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -312,6 +312,10 @@ class PricingModel(ABC):
         Decimal
             The spot price of principal tokens.
         """
+        assert market_state.share_reserves > 0, (
+            "pricing_models.calc_spot_price_from_reserves: ERROR: "
+            f"expected share_reserves > 0, not {market_state.share_reserves}!",
+        )
         # TODO: in general s != y + c*z, we'll want to update this to have s = lp_reserves
         # s = y + c*z
         total_reserves = Decimal(market_state.bond_reserves) + Decimal(market_state.share_price) * Decimal(

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -312,10 +312,6 @@ class PricingModel(ABC):
         Decimal
             The spot price of principal tokens.
         """
-        assert market_state.share_reserves > 0, (
-            "pricing_models.calc_spot_price_from_reserves: ERROR: "
-            f"expected share_reserves > 0, not {market_state.share_reserves}!",
-        )
         # TODO: in general s != y + c*z, we'll want to update this to have s = lp_reserves
         # s = y + c*z
         total_reserves = Decimal(market_state.bond_reserves) + Decimal(market_state.share_price) * Decimal(

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -5,6 +5,7 @@ from functools import wraps
 from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
 from enum import Enum
+import logging
 
 import elfpy.utils.time as time_utils
 
@@ -51,6 +52,12 @@ WEI = 1e-18  # smallest denomination of ether
 # difference between the reserves that will not result in a sign flip when a
 # small trade is put on.
 MAX_RESERVES_DIFFERENCE = 2e10
+
+# The maximum allowed precision error.
+# This value was selected based on one test not passing without it.
+# apply_delta() below checks if reserves are negative within the threshold,
+# and sets them to 0 if so.
+PRECISION_THRESHOLD = 1e-9
 
 
 class TokenType(Enum):
@@ -250,6 +257,17 @@ class MarketState:
         self.bond_buffer += delta.d_bond_buffer
         self.lp_reserves += delta.d_lp_reserves
         self.share_price += delta.d_share_price
+        for key, value in self.__dict__.items():
+            if 0 > value > -PRECISION_THRESHOLD:
+                logging.debug(
+                    ("%s=%s is negative within PRECISION_THRESHOLD=%f, setting it to 0"),
+                    key,
+                    value,
+                    PRECISION_THRESHOLD,
+                )
+                setattr(self, key, 0)
+            else:
+                assert value >= 0, "MarketState values must be non-negative"
 
     def __str__(self):
         output_string = (

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -5,7 +5,6 @@ from functools import wraps
 from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
 from enum import Enum
-import logging
 
 import elfpy.utils.time as time_utils
 
@@ -52,12 +51,6 @@ WEI = 1e-18  # smallest denomination of ether
 # difference between the reserves that will not result in a sign flip when a
 # small trade is put on.
 MAX_RESERVES_DIFFERENCE = 2e10
-
-# The maximum allowed precision error.
-# This value was selected based on one test not passing without it.
-# apply_delta() below checks if reserves are negative within the threshold,
-# and sets them to 0 if so.
-PRECISION_THRESHOLD = 1e-9
 
 
 class TokenType(Enum):
@@ -257,17 +250,6 @@ class MarketState:
         self.bond_buffer += delta.d_bond_buffer
         self.lp_reserves += delta.d_lp_reserves
         self.share_price += delta.d_share_price
-        for key, value in self.__dict__.items():
-            if 0 > value > -PRECISION_THRESHOLD:
-                logging.debug(
-                    ("%s=%s is negative within PRECISION_THRESHOLD=%f, setting it to 0"),
-                    key,
-                    value,
-                    PRECISION_THRESHOLD,
-                )
-                setattr(self, key, 0)
-            else:
-                assert value >= 0, "MarketState values must be non-negative"
 
     def __str__(self):
         output_string = (


### PR DESCRIPTION
need this to get a non-zero max short when bond reserves are zero, but there's plenty of share reserves to facilitate a short (the bootstrap from 0% scenario, without an init_lp)