### PR TITLE
Fixed the APR accounting

### DIFF
--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -19,6 +19,7 @@ from elfpy.types import (
     TradeResult,
 )
 import elfpy.utils.price as price_utils
+import elfpy.utils.time as time_utils
 
 # Set the Decimal precision to be higher than the default of 28. This ensures
 # that the pricing models can safely a lowest possible input of 1e-18 with an
@@ -123,9 +124,9 @@ class PricingModel(ABC):
 
         .. todo:: TODO: Write a test for this function
         """
+        renormalized_time = time_utils.norm_days(time_remaining.days, 365)
         bond_reserves = (market_state.share_reserves / 2) * (
-            market_state.init_share_price
-            * (1 + target_apr * time_remaining.normalized_time) ** (1 / time_remaining.stretched_time)
+            market_state.init_share_price * (1 + target_apr * renormalized_time) ** (1 / time_remaining.stretched_time)
             - market_state.share_price
         )  # y = z/2 * (mu * (1 + rt)**(1/tau) - c)
         return bond_reserves
@@ -162,8 +163,9 @@ class PricingModel(ABC):
 
         """
         # TODO: Write a test for this function
+        renormalized_time = time_utils.norm_days(time_remaining.days, 365)
         share_reserves = bond_reserves / (
-            init_share_price * (1 - target_apr * time_remaining.normalized_time) ** (1 / time_remaining.stretched_time)
+            init_share_price * (1 - target_apr * renormalized_time) ** (1 / time_remaining.stretched_time)
         )  # z = y / (mu * (1 - rt)**(1/tau))
         return share_reserves
 

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -126,9 +126,9 @@ class PricingModel(ABC):
         """
         # Only want to renormalize time for APR ("annual", so hard coded to 365)
         # Don't want to renormalize stretched time
-        renormalized_time = time_utils.norm_days(time_remaining.days, 365)
+        annualized_time = time_utils.norm_days(time_remaining.days, 365)
         bond_reserves = (market_state.share_reserves / 2) * (
-            market_state.init_share_price * (1 + target_apr * renormalized_time) ** (1 / time_remaining.stretched_time)
+            market_state.init_share_price * (1 + target_apr * annualized_time) ** (1 / time_remaining.stretched_time)
             - market_state.share_price
         )  # y = z/2 * (mu * (1 + rt)**(1/tau) - c)
         return bond_reserves
@@ -168,9 +168,9 @@ class PricingModel(ABC):
 
         # Only want to renormalize time for APR ("annual", so hard coded to 365)
         # Don't want to renormalize stretched time
-        renormalized_time = time_utils.norm_days(time_remaining.days, 365)
+        annualized_time = time_utils.norm_days(time_remaining.days, 365)
         share_reserves = bond_reserves / (
-            init_share_price * (1 - target_apr * renormalized_time) ** (1 / time_remaining.stretched_time)
+            init_share_price * (1 - target_apr * annualized_time) ** (1 / time_remaining.stretched_time)
         )  # z = y / (mu * (1 - rt)**(1/tau))
         return share_reserves
 

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -122,8 +122,10 @@ class PricingModel(ABC):
         float
             The expected amount of bonds (token asset) in the pool, given the inputs
 
-        .. todo:: TODO: Write a test for this function
+        .. todo:: Write a test for this function
         """
+        # Only want to renormalize time for APR ("annual", so hard coded to 365)
+        # Don't want to renormalize stretched time
         renormalized_time = time_utils.norm_days(time_remaining.days, 365)
         bond_reserves = (market_state.share_reserves / 2) * (
             market_state.init_share_price * (1 + target_apr * renormalized_time) ** (1 / time_remaining.stretched_time)
@@ -161,8 +163,11 @@ class PricingModel(ABC):
         float
             The expected amount of base asset in the pool, calculated from the provided parameters
 
+        .. todo:: Write a test for this function
         """
-        # TODO: Write a test for this function
+
+        # Only want to renormalize time for APR ("annual", so hard coded to 365)
+        # Don't want to renormalize stretched time
         renormalized_time = time_utils.norm_days(time_remaining.days, 365)
         share_reserves = bond_reserves / (
             init_share_price * (1 - target_apr * renormalized_time) ** (1 / time_remaining.stretched_time)
@@ -253,7 +258,7 @@ class PricingModel(ABC):
         float
             Total liquidity in the pool in terms of base, calculated from the provided parameters
 
-        .. todo:: TODO: Write a test for this function
+        .. todo:: Write a test for this function
         """
         return market_state.share_reserves * share_price
 

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -269,9 +269,10 @@ class YieldSpacePricingModel(PricingModel):
                 "rate=%g,\n\ttime_remaining=%g,\n\tstretched_time_remaining=%g\n\t"
                 "\n\td_shares=%g\n\t(d_base / share_price = %g / %g)"
                 "\n\td_bonds=%g"
-                "\n\t((share_reserves + d_shares) / 2 * (init_share_price * (1 + rate * time_remaining) "
+                "\n\t((share_reserves - d_shares) / 2 * (init_share_price * (1 + apr * annualized_time) "
                 "** (1 / stretched_time_remaining) - share_price) - bond_reserves = "
-                "\n\t(%g + %g) / 2 * (%g * (1 + %g * %g) ** (1 / %g) - %g) - %g)"
+                "\n\t((%g - %g) / 2 * (%g * (1 + %g * %g) "
+                "** (1 / %g) - %g) - %g =\n\t%g"
             ),
             lp_in,
             market_state.share_reserves,
@@ -291,10 +292,11 @@ class YieldSpacePricingModel(PricingModel):
             d_shares,
             market_state.init_share_price,
             rate,
-            time_remaining.normalized_time,
+            annualized_time,
             time_remaining.stretched_time,
             market_state.share_price,
             market_state.bond_reserves,
+            d_bonds,
         )
         return lp_in, d_base, d_bonds
 

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -255,6 +255,7 @@ class YieldSpacePricingModel(PricingModel):
         )
         d_shares = d_base / market_state.share_price
         # TODO: Move this calculation to a helper function.
+        # rate is an APR, which is annual, so we normalize time by 365 to correct for units
         annualized_time = time_utils.norm_days(time_remaining.days, 365)
         d_bonds = (market_state.share_reserves - d_shares) / 2 * (
             market_state.init_share_price * (1 + rate * annualized_time) ** (1 / time_remaining.stretched_time)

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -258,16 +258,15 @@ class YieldSpacePricingModel(PricingModel):
         ) - market_state.bond_reserves
         logging.debug(
             (
-                "inputs: lp_in=%g, share_reserves=%d, "
-                "bond_reserves=%d, base_buffer=%g, "
-                "init_share_price=%g, share_price=%g, lp_reserves=%g, "
-                "rate=%g, time_remaining=%g, stretched_time_remaining=%g"
-                "  d_shares=%g (d_base / share_price = %g / %g)"
-                "  d_bonds=%g\n"
-                "((share_reserves + d_share_reserves) / 2 * (init_share_price * (1 + rate * time_remaining) "
+                "inputs:\n\tlp_in=%g,\n\tshare_reserves=%d, "
+                "bond_reserves=%d,\n\tbase_buffer=%g, "
+                "init_share_price=%g,\n\tshare_price=%g,\n\tlp_reserves=%g,\n\t"
+                "rate=%g,\n\ttime_remaining=%g,\n\tstretched_time_remaining=%g\n\t"
+                "\n\td_shares=%g\n\t(d_base / share_price = %g / %g)"
+                "\n\td_bonds=%g"
+                "\n\t((share_reserves + d_share_reserves) / 2 * (init_share_price * (1 + rate * time_remaining) "
                 "** (1 / stretched_time_remaining) - share_price) - bond_reserves = "
-                "(%g + %g) / 2 * (%g * (1 + %g * %g) "
-                "** (1 / %g) - %g) - %g)"
+                "\n\t(%g + %g) / 2 * (%g * (1 + %g * %g) ** (1 / %g) - %g) - %g)"
             ),
             lp_in,
             market_state.share_reserves,

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -259,7 +259,7 @@ class MarketState:
                 )
                 setattr(self, key, 0)
             else:
-                assert value >= 0, f"MarketState values must be non-negative but instead {key} is {value}"
+                assert value >= 0, f"MarketState values must be non-negative. Error on {key} = {value}"
 
     def __str__(self):
         output_string = (

--- a/src/elfpy/utils/price.py
+++ b/src/elfpy/utils/price.py
@@ -2,7 +2,7 @@
 from __future__ import annotations  # types will be strings by default in 3.11
 
 from elfpy.types import StretchedTime
-
+import elfpy.utils.time as time_utils
 
 ### Spot Price and APR ###
 def calc_apr_from_spot_price(price: float, time_remaining: StretchedTime):
@@ -29,7 +29,8 @@ def calc_apr_from_spot_price(price: float, time_remaining: StretchedTime):
         "utils.price.calc_apr_from_spot_price: ERROR: "
         f"time_remaining.normalized_time should be greater than zero, not {time_remaining.normalized_time}"
     )
-    return (1 - price) / (price * time_remaining.normalized_time)  # r = ((1/p)-1)/t = (1-p)/(pt)
+    renormalized_time = time_utils.norm_days(time_remaining.days, 365)
+    return (1 - price) / (price * renormalized_time)  # r = ((1/p)-1)/t = (1-p)/(pt)
 
 
 def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
@@ -47,4 +48,5 @@ def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
     float
         Spot price of bonds in terms of base, calculated from the provided parameters
     """
-    return 1 / (1 + apr * time_remaining.normalized_time)  # price = 1 / (1 + r * t)
+    renormalized_time = time_utils.norm_days(time_remaining.days, 365)
+    return 1 / (1 + apr * renormalized_time)  # price = 1 / (1 + r * t)

--- a/src/elfpy/utils/price.py
+++ b/src/elfpy/utils/price.py
@@ -29,8 +29,8 @@ def calc_apr_from_spot_price(price: float, time_remaining: StretchedTime):
         "utils.price.calc_apr_from_spot_price: ERROR: "
         f"time_remaining.normalized_time should be greater than zero, not {time_remaining.normalized_time}"
     )
-    renormalized_time = time_utils.norm_days(time_remaining.days, 365)
-    return (1 - price) / (price * renormalized_time)  # r = ((1/p)-1)/t = (1-p)/(pt)
+    annualized_time = time_utils.norm_days(time_remaining.days, 365)
+    return (1 - price) / (price * annualized_time)  # r = ((1/p)-1)/t = (1-p)/(pt)
 
 
 def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
@@ -48,5 +48,5 @@ def calc_spot_price_from_apr(apr: float, time_remaining: StretchedTime):
     float
         Spot price of bonds in terms of base, calculated from the provided parameters
     """
-    renormalized_time = time_utils.norm_days(time_remaining.days, 365)
-    return 1 / (1 + apr * renormalized_time)  # price = 1 / (1 + r * t)
+    annualized_time = time_utils.norm_days(time_remaining.days, 365)
+    return 1 / (1 + apr * annualized_time)  # price = 1 / (1 + r * t)

--- a/tests/pricing_models/test_calc_spot_price.py
+++ b/tests/pricing_models/test_calc_spot_price.py
@@ -1,6 +1,4 @@
-# base.calc_spot_price_from_reserves
-# utils.price.calc_spot_price_from_apr
-
+"""Testing for spot price calculations in Pricing Models and Price utils"""
 import unittest
 
 import numpy as np
@@ -8,6 +6,9 @@ import numpy as np
 from elfpy.pricing_models.base import PricingModel
 import elfpy.utils.price as price_utils
 from elfpy.types import MarketState, StretchedTime
+
+
+# pylint: disable=duplicate-code
 
 
 class TestSpotPriceCalculations(unittest.TestCase):
@@ -96,6 +97,7 @@ class TestSpotPriceCalculations(unittest.TestCase):
             )
 
     def test_calc_spot_price_from_apr(self):
+        """Test the price utils function for calculating spot price"""
         test_cases = [
             # test 1: r = 0.05; d=90
             {
@@ -160,6 +162,13 @@ class TestSpotPriceCalculations(unittest.TestCase):
             )
 
     def test_calc_spot_price_consistency(self):
+        """Test consistency of spot price calculations
+
+        compute spot price from reserves using pricing model
+        compute apr from reserves using pricing model
+        compute spot price from apr using price utils
+        compare spot price calculations
+        """
         test_cases = [
             # test 1: 500k share_reserves; 500k bond_reserves
             #   1 share price; 1 init_share_price

--- a/tests/pricing_models/test_calc_spot_price.py
+++ b/tests/pricing_models/test_calc_spot_price.py
@@ -1,0 +1,45 @@
+# base.calc_spot_price_from_reserves
+# utils.price.calc_spot_price_from_apr
+
+import unittest
+from elfpy.pricing_models.base import PricingModel
+import elfpy.utils.price as price_utils
+from elfpy.types import MarketState, StretchedTime
+
+
+class TestSpotPriceCalculations(unittest.TestCase):
+    def test_calc_spot_price_from_reserves(self):
+
+        # def calc_spot_price_from_reserves(
+        # self,
+        # market_state: MarketState,
+        # time_remaining: StretchedTime,
+        # ) -> float:
+
+        test_cases = [
+            # test 1: 500k share_reserves; 500k bond_reserves
+            #   1 share price; 1 init_share_price
+            #   90d elapsed; time_stretch=1; norm=365
+            {
+                "market_state": MarketState(
+                    share_reserves=500000,  # z = 500000
+                    bond_reserves=500000,  # y = 500000
+                    share_price=1,  # c = 1
+                    init_share_price=1,  # u = 1
+                ),
+                "time_remaining": StretchedTime(
+                    days=90,
+                    time_stretch=1,
+                    normalizing_constant=365,
+                ),
+                # tau = days / normalizing_constant / time_stretch
+                # s = y + c*z
+                # p = ((2y + cz)/(u*z))^(-tau)
+                # p = ((2 * 500000 + 1 * 500000) / (1 * 500000))**((-(90 / 1 / 365))
+                "expected_result": 0.7626998539403097,
+            },
+        ]
+
+    def test_calc_spot_price_from_apr(self):
+        # (price: float, time_remaining: StretchedTime)
+        pass

--- a/tests/pricing_models/test_calc_spot_price.py
+++ b/tests/pricing_models/test_calc_spot_price.py
@@ -2,30 +2,32 @@
 # utils.price.calc_spot_price_from_apr
 
 import unittest
+
+import numpy as np
+
 from elfpy.pricing_models.base import PricingModel
 import elfpy.utils.price as price_utils
 from elfpy.types import MarketState, StretchedTime
 
 
 class TestSpotPriceCalculations(unittest.TestCase):
+    """Test spot price calculation in base pricing model & price utils"""
+
     def test_calc_spot_price_from_reserves(self):
+        """Test base pricing model calculation
 
-        # def calc_spot_price_from_reserves(
-        # self,
-        # market_state: MarketState,
-        # time_remaining: StretchedTime,
-        # ) -> float:
-
+        .. todo:: write failure tests
+        """
         test_cases = [
             # test 1: 500k share_reserves; 500k bond_reserves
             #   1 share price; 1 init_share_price
             #   90d elapsed; time_stretch=1; norm=365
             {
                 "market_state": MarketState(
-                    share_reserves=500000,  # z = 500000
-                    bond_reserves=500000,  # y = 500000
-                    share_price=1,  # c = 1
-                    init_share_price=1,  # u = 1
+                    share_reserves=500000,  # z
+                    bond_reserves=500000,  # y
+                    share_price=1,  # c
+                    init_share_price=1,  # u
                 ),
                 "time_remaining": StretchedTime(
                     days=90,
@@ -35,11 +37,195 @@ class TestSpotPriceCalculations(unittest.TestCase):
                 # tau = days / normalizing_constant / time_stretch
                 # s = y + c*z
                 # p = ((2y + cz)/(u*z))^(-tau)
-                # p = ((2 * 500000 + 1 * 500000) / (1 * 500000))**((-(90 / 1 / 365))
+                # p = ((2 * 500000 + 1 * 500000) / (1 * 500000))**(-(90 / 1 / 365))
                 "expected_result": 0.7626998539403097,
             },
+            # test 2: 250k share_reserves; 500k bond_reserves
+            #   2 share price; 1.5 init_share_price
+            #   90d elapsed; time_stretch=1; norm=365
+            {
+                "market_state": MarketState(
+                    share_reserves=250000,  # z
+                    bond_reserves=500000,  # y
+                    share_price=2,  # c
+                    init_share_price=1.5,  # u
+                ),
+                "time_remaining": StretchedTime(
+                    days=90,
+                    time_stretch=1,
+                    normalizing_constant=365,
+                ),
+                # tau = days / normalizing_constant / time_stretch
+                # s = y + c*z
+                # p = ((2y + cz)/(u*z))^(-tau)
+                # p = ((2 * 500000 + 2 * 250000) / (1.5 * 250000))**(-(90 / 1 / 365))
+                "expected_result": 0.7104718111828882,
+            },
+            # test 3: 250k share_reserves; 300k bond_reserves
+            #   2 share price; 1.5 init_share_price
+            #   180d elapsed; time_stretch=0.7; norm=365
+            {
+                "market_state": MarketState(
+                    share_reserves=250000,  # z
+                    bond_reserves=300000,  # y
+                    share_price=2,  # c
+                    init_share_price=1.5,  # u
+                ),
+                "time_remaining": StretchedTime(
+                    days=180,
+                    time_stretch=0.7,
+                    normalizing_constant=365,
+                ),
+                # tau = days / normalizing_constant / time_stretch
+                # s = y + c*z
+                # p = ((2y + cz)/(u*z))^(-tau)
+                # p = ((2 * 300000 + 2 * 250000) / (1.5 * 250000))**(-(180 / 0.7 / 365))
+                "expected_result": 0.4685364947185249,
+            },
         ]
+        pricing_model = PricingModel()
+        for test_number, test_case in enumerate(test_cases):
+            spot_price = pricing_model.calc_spot_price_from_reserves(
+                market_state=test_case["market_state"],
+                time_remaining=test_case["time_remaining"],
+            )
+            np.testing.assert_almost_equal(
+                spot_price,
+                test_case["expected_result"],
+                err_msg=f"{test_number=} failed, {spot_price=}, {test_case['expected_result']}",
+            )
 
     def test_calc_spot_price_from_apr(self):
-        # (price: float, time_remaining: StretchedTime)
-        pass
+        test_cases = [
+            # test 1: r = 0.05; d=90
+            {
+                "apr": 0.05,
+                "time_remaining": StretchedTime(
+                    days=90, time_stretch=1, normalizing_constant=365  # not used  # not used
+                ),
+                # t = time_remaining / 365
+                # p = 1 / (1 + r * t)
+                # p = 1 / (1 + 0.05 * (90 / 365))
+                "expected_result": 0.9878213802435724,
+            },
+            # test 2: r = 0.025; d=90
+            {
+                "apr": 0.025,
+                "time_remaining": StretchedTime(
+                    days=90,
+                    time_stretch=1,  # not used
+                    normalizing_constant=90,  # not used
+                ),
+                # t = time_remaining / 365
+                # p = 1 / (1 + r * t)
+                # p = 1 / (1 + 0.025 * (90 / 365))
+                "expected_result": 0.9938733832539143,
+            },
+            # test 3: r = 0.025; d=180
+            {
+                "apr": 0.025,
+                "time_remaining": StretchedTime(
+                    days=180,
+                    time_stretch=0.5,  # not used
+                    normalizing_constant=270,  # not used
+                ),
+                # t = time_remaining / 365
+                # p = 1 / (1 + r * t)
+                # p = 1 / (1 + 0.025 * (180 / 365))
+                "expected_result": 0.9878213802435724,
+            },
+            # test 3: r = 0.1; d=365
+            {
+                "apr": 0.1,
+                "time_remaining": StretchedTime(
+                    days=365,
+                    time_stretch=1.0,  # not used
+                    normalizing_constant=365,  # not used
+                ),
+                # t = time_remaining / 365
+                # p = 1 / (1 + r * t)
+                # p = 1 / (1 + 0.1 * (365 / 365))
+                "expected_result": 0.9090909090909091,
+            },
+        ]
+        for test_number, test_case in enumerate(test_cases):
+            spot_price = price_utils.calc_spot_price_from_apr(
+                apr=test_case["apr"],
+                time_remaining=test_case["time_remaining"],
+            )
+            np.testing.assert_almost_equal(
+                spot_price,
+                test_case["expected_result"],
+                err_msg=f"{test_number=} failed, {spot_price=}, {test_case['expected_result']}",
+            )
+
+    def test_calc_spot_price_consistency(self):
+        test_cases = [
+            # test 1: 500k share_reserves; 500k bond_reserves
+            #   1 share price; 1 init_share_price
+            #   90d elapsed; time_stretch=1; norm=365
+            {
+                "market_state": MarketState(
+                    share_reserves=500000,  # z
+                    bond_reserves=500000,  # y
+                    share_price=1,  # c
+                    init_share_price=1,  # u
+                ),
+                "time_remaining": StretchedTime(
+                    days=90,
+                    time_stretch=1,
+                    normalizing_constant=365,
+                ),
+            },
+            # test 2: 250k share_reserves; 500k bond_reserves
+            #   2 share price; 1.5 init_share_price
+            #   90d elapsed; time_stretch=1; norm=365
+            {
+                "market_state": MarketState(
+                    share_reserves=250000,  # z
+                    bond_reserves=500000,  # y
+                    share_price=2,  # c
+                    init_share_price=1.5,  # u
+                ),
+                "time_remaining": StretchedTime(
+                    days=90,
+                    time_stretch=1,
+                    normalizing_constant=365,
+                ),
+            },
+            # test 3: 250k share_reserves; 300k bond_reserves
+            #   2 share price; 1.5 init_share_price
+            #   180d elapsed; time_stretch=0.7; norm=365
+            {
+                "market_state": MarketState(
+                    share_reserves=250000,  # z
+                    bond_reserves=300000,  # y
+                    share_price=2,  # c
+                    init_share_price=1.5,  # u
+                ),
+                "time_remaining": StretchedTime(
+                    days=180,
+                    time_stretch=0.7,
+                    normalizing_constant=365,
+                ),
+            },
+        ]
+        pricing_model = PricingModel()
+        for test_number, test_case in enumerate(test_cases):
+            pm_spot_price = pricing_model.calc_spot_price_from_reserves(
+                market_state=test_case["market_state"],
+                time_remaining=test_case["time_remaining"],
+            )
+            pm_apr = pricing_model.calc_apr_from_reserves(
+                market_state=test_case["market_state"],
+                time_remaining=test_case["time_remaining"],
+            )
+            util_spot_price = price_utils.calc_spot_price_from_apr(
+                apr=pm_apr,
+                time_remaining=test_case["time_remaining"],
+            )
+            np.testing.assert_almost_equal(
+                pm_spot_price,
+                util_spot_price,
+                err_msg=f"{test_number=} failed, {pm_spot_price=}, {util_spot_price=}",
+            )

--- a/tests/pricing_models/test_pricing_model_utils.py
+++ b/tests/pricing_models/test_pricing_model_utils.py
@@ -173,7 +173,10 @@ class BasePricingModelUtilsTest(unittest.TestCase):
                 )
 
     def run_calc_k_const_test(self, pricing_model: PricingModel):
-        """Unit tests for calc_k_const function"""
+        """Unit tests for calc_k_const function
+
+        .. todo:: fix comments to actually reflect test case values
+        """
 
         test_cases = [
             # test 1: 500k share_reserves; 500k bond_reserves

--- a/tests/pricing_models/test_pricing_model_utils.py
+++ b/tests/pricing_models/test_pricing_model_utils.py
@@ -180,7 +180,7 @@ class BasePricingModelUtilsTest(unittest.TestCase):
             #   1 share price; 1 init_share_price; 3mo elapsed
             {
                 "market_state": MarketState(
-                    share_reserves=500000,  # x = 500000
+                    share_reserves=500000,  # z = 500000
                     bond_reserves=500000,  # y = 500000
                     share_price=1,  # c = 1
                     init_share_price=1,  # u = 1
@@ -217,8 +217,8 @@ class BasePricingModelUtilsTest(unittest.TestCase):
                 ),
                 "time_elapsed": 0.50,  # t = 0.50
                 # k = c/u * (u*y)**t + (2y+c*x)**t
-                #     = 1/1 * (1*5000000)**0.50 + (2*5000000+1*5000000)**0.50
-                #     = 61.587834600530776
+                #     = 2/1.5 * (1.5*5000000)**0.50 + (2*5000000+2*5000000)**0.50
+                #     = 8123.619671700687
                 "expected_result": 8123.619671700687,
             },
             # test 4: 0M share_reserves; 5M bond_reserves

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -11,6 +11,7 @@ from elfpy.wallet import Wallet, Long, Short
 from elfpy.types import MarketDeltas, StretchedTime, MarketState, Config
 from elfpy.markets import Market
 from elfpy.pricing_models.base import PricingModel
+from elfpy.pricing_models.hyperdrive import HyperdrivePricingModel
 
 import elfpy.utils.outputs as output_utils  # utilities for file outputs
 
@@ -381,3 +382,22 @@ class MarketTestsOneFunction(BaseMarketTest):
         self.run_market_test_close_short(
             agent_policy=agent_policy, expected_deltas=expected_deltas, partial=0.5, tick_time=True
         )
+
+    def test_example(self):
+        pricing_model = HyperdrivePricingModel()
+        position_duration = StretchedTime(
+            days=91.25, time_stretch=pricing_model.calc_time_stretch(0.2), normalizing_constant=91.25
+        )
+        share_reserves = 1_000
+        market = Market(
+            pricing_model,
+            MarketState(
+                share_reserves=share_reserves,
+                bond_reserves=pricing_model.calc_bond_reserves(
+                    0.2, position_duration, MarketState(share_reserves=share_reserves)
+                ),
+            ),
+            position_duration,
+        )
+
+        print(f"{market.rate=}")

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -383,21 +383,26 @@ class MarketTestsOneFunction(BaseMarketTest):
             agent_policy=agent_policy, expected_deltas=expected_deltas, partial=0.5, tick_time=True
         )
 
-    def test_example(self):
+    def test_apr(self):
+        """open short of 100 bonds, close short of 50 bonds, one tick later"""
         pricing_model = HyperdrivePricingModel()
         position_duration = StretchedTime(
             days=91.25, time_stretch=pricing_model.calc_time_stretch(0.2), normalizing_constant=91.25
         )
         share_reserves = 1_000
-        market = Market(
-            pricing_model,
-            MarketState(
-                share_reserves=share_reserves,
-                bond_reserves=pricing_model.calc_bond_reserves(
-                    0.2, position_duration, MarketState(share_reserves=share_reserves)
-                ),
-            ),
-            position_duration,
-        )
+        target_aprs = [0.001, 0.01, 0.2, 0.123456789, 1]
 
-        print(f"{market.rate=}")
+        for target_apr in target_aprs:
+            market = Market(
+                pricing_model,
+                MarketState(
+                    share_reserves=share_reserves,
+                    bond_reserves=pricing_model.calc_bond_reserves(
+                        target_apr, position_duration, MarketState(share_reserves=share_reserves)
+                    ),
+                ),
+                position_duration,
+            )
+
+            # TODO have this be exact once we fix #146
+            self.assertAlmostEqual(market.rate, target_apr, 12)


### PR DESCRIPTION
I made changes to the APR accounting when fixing the flat+curve model by adding a normalizing constant. It looks like those changes were dropped; however, the changes are required for the APR accounting to work correctly (otherwise we aren't computing APR since it wouldn't be annualized). Running `pytest -s -k test_example` shows that the low-level accounting functions are working properly. I inspected a breaking test in `test_trade` and found that the initial bootstrapping of the market using the initial LP agent works gives the expected APR. The problem lies elsewhere in the logic of the test or the initial LP agent.

An easier way to fix this may be to abandon the init LP agent entirely and use an approach that is more similar to that used in the contract (using `Market`'s `initialize function).