### PR TITLE
standardize inputs and reserves checks

### DIFF
--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -465,6 +465,13 @@ class Market:
             rate = 0
         else:
             rate = self.rate
+        # sanity check inputs
+        self.pricing_model.check_input_assertions(
+            quantity=Quantity(amount=trade_amount, unit=TokenType.PT),  # temporary Quantity object just for this check
+            market_state=self.market_state,
+            time_remaining=self.position_duration,
+        )
+        # perform the trade
         lp_out, d_base_reserves, d_token_reserves = self.pricing_model.calc_lp_out_given_tokens_in(
             d_base=trade_amount,
             rate=rate,
@@ -489,6 +496,13 @@ class Market:
         trade_amount: float,
     ) -> tuple[MarketDeltas, Wallet]:
         """Computes new deltas for bond & share reserves after liquidity is removed"""
+        # sanity check inputs
+        self.pricing_model.check_input_assertions(
+            quantity=Quantity(amount=trade_amount, unit=TokenType.PT),  # temporary Quantity object just for this check
+            market_state=self.market_state,
+            time_remaining=self.position_duration,
+        )
+        # perform the trade
         lp_in, d_base_reserves, d_token_reserves = self.pricing_model.calc_tokens_out_given_lp_in(
             lp_in=trade_amount,
             rate=self.rate,

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -331,9 +331,6 @@ class PricingModel(ABC):
             market_state.share_reserves
         )
         # p = ((y + s)/(mu*z))^(-tau) = ((2y + cz)/(mu*z))^(-tau)
-        assert market_state.init_share_price != 0, "init_share_price cannot be zero"
-        if market_state.share_reserves == 0:
-            return Decimal(np.inf)
         spot_price = (
             (Decimal(market_state.bond_reserves) + total_reserves)
             / (Decimal(market_state.init_share_price) * Decimal(market_state.share_reserves))

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -586,17 +586,21 @@ class PricingModel(ABC):
             f"expected reserves_difference < {MAX_RESERVES_DIFFERENCE}, not {reserves_difference}!"
         )
         assert 1 >= market_state.trade_fee_percent >= 0, (
-            "pricing_models.calc_in_given_out: ERROR: "
+            "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 >= trade_fee_percent >= 0, not {market_state.trade_fee_percent}!"
         )
         assert 1 >= market_state.redemption_fee_percent >= 0, (
-            "pricing_models.calc_in_given_out: ERROR: "
+            "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 >= redemption_fee_percent >= 0, not {market_state.redemption_fee_percent}!"
         )
         # TODO: convert this to a check for 1>=time and fix tests as necessary
         assert 1 > time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_in_given_out: ERROR: "
+            "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 > time_remaining.stretched_time >= 0, not {time_remaining.stretched_time}!"
+        )
+        assert 1 > time_remaining.normalized_time >= 0, (
+            "pricing_models.check_input_assertions: ERROR: "
+            f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
         )
 
     # TODO: Add checks for TradeResult's other outputs.

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -593,12 +593,11 @@ class PricingModel(ABC):
             "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 >= redemption_fee_percent >= 0, not {market_state.redemption_fee_percent}!"
         )
-        # TODO: convert this to a check for 1>=time and fix tests as necessary
-        assert 1 > time_remaining.stretched_time >= 0, (
+        assert 1 >= time_remaining.stretched_time >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 > time_remaining.stretched_time >= 0, not {time_remaining.stretched_time}!"
         )
-        assert 1 > time_remaining.normalized_time >= 0, (
+        assert 1 >= time_remaining.normalized_time >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
         )

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -289,6 +289,9 @@ class PricingModel(ABC):
         float
             The spot price of principal tokens.
         """
+        assert market_state.init_share_price != 0, "init_share_price cannot be zero"
+        if market_state.share_reserves == 0:
+            return np.inf
         return float(
             self._calc_spot_price_from_reserves_high_precision(market_state=market_state, time_remaining=time_remaining)
         )

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -568,14 +568,6 @@ class PricingModel(ABC):
             "pricing_models.check_input_assertions: ERROR: "
             f"expected quantity.amount >= {WEI}, not {quantity.amount}!"
         )
-        assert market_state.share_reserves >= WEI, (
-            "pricing_models.check_input_assertions: ERROR: "
-            f"expected share_reserves >= {WEI}, not {market_state.share_reserves}!"
-        )
-        assert market_state.bond_reserves >= WEI or market_state.bond_reserves == 0, (
-            "pricing_models.check_input_assertions: ERROR: "
-            f"expected bond_reserves >= {WEI} or bond_reserves == 0, not {market_state.bond_reserves}!"
-        )
         assert market_state.share_price >= market_state.init_share_price >= 1, (
             f"pricing_models.check_input_assertions: ERROR: "
             f"expected share_price >= init_share_price >= 1, not share_price={market_state.share_price} "

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -6,6 +6,7 @@ import copy
 import decimal
 from decimal import Decimal
 
+import numpy as np
 from elfpy import (
     MAX_RESERVES_DIFFERENCE,
     WEI,
@@ -330,6 +331,9 @@ class PricingModel(ABC):
             market_state.share_reserves
         )
         # p = ((y + s)/(mu*z))^(-tau) = ((2y + cz)/(mu*z))^(-tau)
+        assert market_state.init_share_price != 0, "init_share_price cannot be zero"
+        if market_state.share_reserves == 0:
+            return Decimal(np.inf)
         spot_price = (
             (Decimal(market_state.bond_reserves) + total_reserves)
             / (Decimal(market_state.init_share_price) * Decimal(market_state.share_reserves))

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -592,11 +592,11 @@ class PricingModel(ABC):
         )
         assert 1 >= time_remaining.stretched_time >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
-            f"expected 1 > time_remaining.stretched_time >= 0, not {time_remaining.stretched_time}!"
+            f"expected 1 >= time_remaining.stretched_time >= 0, not {time_remaining.stretched_time}!"
         )
         assert 1 >= time_remaining.normalized_time >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
-            f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
+            f"expected 1 >= time_remaining >= 0, not {time_remaining.normalized_time}!"
         )
 
     # TODO: Add checks for TradeResult's other outputs.

--- a/src/elfpy/pricing_models/hyperdrive.py
+++ b/src/elfpy/pricing_models/hyperdrive.py
@@ -112,8 +112,15 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
         d_bonds = out_amount * (1 - normalized_time)
         d_shares = d_bonds / share_price
 
-        # TODO: Verify that this is needed.
-        market_state = copy.copy(market_state)
+        # mock up the effect of the trade on a copy that isn't frozen
+        market_state = MarketState(
+            share_reserves=market_state.share_reserves,
+            bond_reserves=market_state.bond_reserves,
+            share_price=market_state.share_price,
+            init_share_price=market_state.init_share_price,
+            trade_fee_percent=market_state.trade_fee_percent,
+            redemption_fee_percent=market_state.redemption_fee_percent,
+        )
 
         # TODO: This is somewhat strange since these updates never actually hit the reserves.
         # Redeem the matured bonds 1:1 and simulate these updates hitting the reserves.

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -52,37 +52,6 @@ class YieldSpacePricingModel(PricingModel):
             y = \frac{(z + \Delta z)(\mu \cdot (\frac{1}{1 + r \cdot t(d)})^{\frac{1}{\tau(d_b)}} - c)}{2}
 
         """
-        assert d_base > 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected d_base > 0, not {d_base}!"
-        assert market_state.share_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR:  "
-            f"Expected share_reserves >= 0, not {market_state.share_reserves}!"
-        )
-        assert market_state.bond_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected bond_reserves >= 0, not {market_state.bond_reserves}!"
-        )
-        assert market_state.base_buffer >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected base_buffer >= 0, not {market_state.base_buffer}!"
-        )
-        assert market_state.lp_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected lp_reserves >= 0, not {market_state.lp_reserves}!"
-        )
-        assert rate >= 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected rate >= 0, not {rate}!"
-        assert 1 >= time_remaining.normalized_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"expected 1 >= time_remaining >= 0, not {time_remaining.normalized_time}!"
-        )
-        assert time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"expected stretched_time_remaining >= 0, not {time_remaining.stretched_time}!"
-        )
-        assert market_state.share_price >= market_state.init_share_price >= 1, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            "expected share_price >= init_share_price >= 1, not "
-            f"share_price={market_state.share_price} and init_share_price={market_state.init_share_price}!"
-        )
         d_shares = d_base / market_state.share_price
         if market_state.share_reserves > 0:  # normal case where we have some share reserves
             # TODO: We need to update these LP calculations to address the LP
@@ -159,38 +128,6 @@ class YieldSpacePricingModel(PricingModel):
             y = \frac{(z - \Delta z)(\mu \cdot (\frac{1}{1 + r \cdot t(d)})^{\frac{1}{\tau(d_b)}} - c)}{2}
 
         """
-        assert d_base > 0, f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected d_base > 0, not {d_base}!"
-        assert market_state.share_reserves >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected share_reserves >= 0, not {market_state.share_reserves}!"
-        )
-        assert market_state.bond_reserves >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected bond_reserves >= 0, not {market_state.bond_reserves}!"
-        )
-        assert market_state.base_buffer >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected base_buffer >= 0, not {market_state.base_buffer}!"
-        )
-        assert market_state.lp_reserves >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected lp_reserves >= 0, not {market_state.lp_reserves}!"
-        )
-        assert rate >= 0, f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected rate >= 0, not {rate}!"
-        # TODO: convert this to a check for 1>=time and fix tests as necessary
-        assert 1 > time_remaining.normalized_time >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
-        )
-        assert time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"expected stretched_time_remaining >= 0, not {time_remaining.stretched_time}!"
-        )
-        assert market_state.share_price >= market_state.init_share_price >= 1, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            "expected share_price >= init_share_price >= 1, not "
-            f"share_price={market_state.share_price}, and init_share_price={market_state.init_share_price}"
-        )
         d_shares = d_base / market_state.share_price
         lp_in = (d_shares * market_state.lp_reserves) / (
             market_state.share_reserves - market_state.base_buffer / market_state.share_price
@@ -214,39 +151,6 @@ class YieldSpacePricingModel(PricingModel):
 
         .. todo:: add test for this function; improve function documentation w/ parameters, returns, and equations used
         """
-        assert lp_in > 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected lp_in > 0, not {lp_in}!"
-        assert market_state.share_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected share_reserves >= 0, not {market_state.share_reserves}!"
-        )
-        assert market_state.bond_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected bond_reserves >= 0, not {market_state.bond_reserves}!"
-        )
-        # TODO: #146 These asserts should check for 0 -- the buffers should never go below 0
-        # We think that this is happening due to an rounding error, based on the size of the difference
-        assert market_state.base_buffer >= -1e-8, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected base_buffer >= 0, not {market_state.base_buffer}!"
-        )
-        assert market_state.lp_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected lp_reserves >= 0, not {market_state.lp_reserves}!"
-        )
-        assert rate >= 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected rate >= 0, not {rate}!"
-        assert 1 >= time_remaining.normalized_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected 1 >= time_remaining >= 0, not {time_remaining.normalized_time}!"
-        )
-        assert time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"expected stretched_time_remaining >= 0, not {time_remaining.stretched_time}!"
-        )
-        assert market_state.share_price >= market_state.init_share_price >= 1, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            "expected share_price >= init_share_price >= 1, not "
-            f"share_price={market_state.share_price}, and init_share_price={market_state.init_share_price}"
-        )
         d_base = (
             market_state.share_price
             * (market_state.share_reserves - market_state.base_buffer)

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -259,7 +259,6 @@ class MarketState:
     init_share_price: float = 1.0
 
     # fee percents
-
     trade_fee_percent: float = 0.0
     redemption_fee_percent: float = 0.0
 

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -62,13 +62,6 @@ def freezable(frozen: bool = False, no_new_attribs: bool = False) -> Type:
     return decorator
 
 
-# The maximum allowed precision error.
-# This value was selected based on one test not passing without it.
-# apply_delta() below checks if reserves are negative within the threshold,
-# and sets them to 0 if so.
-PRECISION_THRESHOLD = 1e-9
-
-
 class TokenType(Enum):
     r"""A type of token"""
 
@@ -284,7 +277,9 @@ class MarketState:
                 )
                 setattr(self, key, 0)
             else:
-                assert value >= 0, f"MarketState values must be non-negative. Error on {key} = {value}"
+                assert (
+                    value > -PRECISION_THRESHOLD
+                ), f"MarketState values must be > {-PRECISION_THRESHOLD}. Error on {key} = {value}"
 
     def __str__(self):
         output_string = (

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -6,7 +6,6 @@ from functools import wraps
 from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
 from enum import Enum
-import logging
 import json
 
 import numpy as np

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -269,17 +269,6 @@ class MarketState:
         self.bond_buffer += delta.d_bond_buffer
         self.lp_reserves += delta.d_lp_reserves
         self.share_price += delta.d_share_price
-        for key, value in self.__dict__.items():
-            if 0 > value > -PRECISION_THRESHOLD:
-                logging.debug(
-                    ("%s=%s is negative within PRECISION_THRESHOLD=%f, setting it to 0"),
-                    key,
-                    value,
-                    PRECISION_THRESHOLD,
-                )
-                setattr(self, key, 0)
-            else:
-                assert value >= 0, "MarketState values must be non-negative"
 
         # this is an imperfect solution to rounding errors, but it works for now
         # ideally we'd find a more thorough solution than just catching errors

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -6,6 +6,7 @@ from functools import wraps
 from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
 from enum import Enum
+import logging
 import json
 
 import numpy as np
@@ -60,6 +61,13 @@ def freezable(frozen: bool = False, no_new_attribs: bool = False) -> Type:
         return FrozenClass
 
     return decorator
+
+
+# The maximum allowed precision error.
+# This value was selected based on one test not passing without it.
+# apply_delta() below checks if reserves are negative within the threshold,
+# and sets them to 0 if so.
+PRECISION_THRESHOLD = 1e-9
 
 
 class TokenType(Enum):
@@ -263,6 +271,17 @@ class MarketState:
         self.bond_buffer += delta.d_bond_buffer
         self.lp_reserves += delta.d_lp_reserves
         self.share_price += delta.d_share_price
+        for key, value in self.__dict__.items():
+            if 0 > value > -PRECISION_THRESHOLD:
+                logging.debug(
+                    ("%s=%s is negative within PRECISION_THRESHOLD=%f, setting it to 0"),
+                    key,
+                    value,
+                    PRECISION_THRESHOLD,
+                )
+                setattr(self, key, 0)
+            else:
+                assert value >= 0, "MarketState values must be non-negative"
 
         # this is an imperfect solution to rounding errors, but it works for now
         # ideally we'd find a more thorough solution than just catching errors

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -113,13 +113,10 @@ class Wallet:
 
         .. todo:: TODO: return a dataclass instead of dict to avoid having to check keys & the get_state_keys func
         """
-        lp_token_value = (
-            market.market_state.share_reserves
-            * market.market_state.share_price
-            * (self.lp_tokens / market.market_state.lp_reserves)
-            if self.lp_tokens > 0
-            else 0.0
-        )
+        share_of_pool = self.lp_tokens / market.market_state.lp_reserves if market.market_state.lp_reserves > 0 else 0.0
+        pool_value = market.market_state.bond_reserves * market.spot_price / market.market_state.share_price
+        pool_value += market.market_state.share_reserves * market.market_state.share_price
+        lp_token_value = pool_value * share_of_pool
         share_reserves = market.market_state.share_reserves
         # compute long values in units of base
         longs_value = 0

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -113,14 +113,13 @@ class Wallet:
 
         .. todo:: TODO: return a dataclass instead of dict to avoid having to check keys & the get_state_keys func
         """
+        lp_token_value = 0
         if self.lp_tokens > 0:  # proceed further only if the agent has LP tokens
             if market.market_state.lp_reserves > 0:  # avoid divide by zero
                 share_of_pool = self.lp_tokens / market.market_state.lp_reserves
                 pool_value = market.market_state.bond_reserves * market.spot_price  # in base
                 pool_value += market.market_state.share_reserves * market.market_state.share_price  # in base
                 lp_token_value = pool_value * share_of_pool  # in base
-            else:
-                lp_token_value = 0
         share_reserves = market.market_state.share_reserves
         # compute long values in units of base
         longs_value = 0

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -113,13 +113,13 @@ class Wallet:
 
         .. todo:: TODO: return a dataclass instead of dict to avoid having to check keys & the get_state_keys func
         """
-        lp_token_value = 0
-        if self.lp_tokens > 0:  # proceed further only if the agent has LP tokens
-            if market.market_state.lp_reserves > 0:  # avoid divide by zero
-                share_of_pool = self.lp_tokens / market.market_state.lp_reserves
-                pool_value = market.market_state.bond_reserves * market.spot_price  # in base
-                pool_value += market.market_state.share_reserves * market.market_state.share_price  # in base
-                lp_token_value = pool_value * share_of_pool  # in base
+        lp_token_value = (
+            market.market_state.share_reserves
+            * market.market_state.share_price
+            * (self.lp_tokens / market.market_state.lp_reserves)
+            if self.lp_tokens > 0
+            else 0.0
+        )
         share_reserves = market.market_state.share_reserves
         # compute long values in units of base
         longs_value = 0

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -114,9 +114,9 @@ class Wallet:
         .. todo:: TODO: return a dataclass instead of dict to avoid having to check keys & the get_state_keys func
         """
         share_of_pool = self.lp_tokens / market.market_state.lp_reserves if market.market_state.lp_reserves > 0 else 0.0
-        pool_value = market.market_state.bond_reserves * market.spot_price / market.market_state.share_price
-        pool_value += market.market_state.share_reserves * market.market_state.share_price
-        lp_token_value = pool_value * share_of_pool
+        pool_value = market.market_state.bond_reserves * market.spot_price  # in base
+        pool_value += market.market_state.share_reserves * market.market_state.share_price  # in base
+        lp_token_value = pool_value * share_of_pool  # in base
         share_reserves = market.market_state.share_reserves
         # compute long values in units of base
         longs_value = 0

--- a/src/elfpy/wallet.py
+++ b/src/elfpy/wallet.py
@@ -113,10 +113,14 @@ class Wallet:
 
         .. todo:: TODO: return a dataclass instead of dict to avoid having to check keys & the get_state_keys func
         """
-        share_of_pool = self.lp_tokens / market.market_state.lp_reserves if market.market_state.lp_reserves > 0 else 0.0
-        pool_value = market.market_state.bond_reserves * market.spot_price  # in base
-        pool_value += market.market_state.share_reserves * market.market_state.share_price  # in base
-        lp_token_value = pool_value * share_of_pool  # in base
+        if self.lp_tokens > 0:  # proceed further only if the agent has LP tokens
+            if market.market_state.lp_reserves > 0:  # avoid divide by zero
+                share_of_pool = self.lp_tokens / market.market_state.lp_reserves
+                pool_value = market.market_state.bond_reserves * market.spot_price  # in base
+                pool_value += market.market_state.share_reserves * market.market_state.share_price  # in base
+                lp_token_value = pool_value * share_of_pool  # in base
+            else:
+                lp_token_value = 0
         share_reserves = market.market_state.share_reserves
         # compute long values in units of base
         longs_value = 0

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -141,7 +141,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                     redemption_fee_percent=0.01,
                 ),
                 time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
+                exception_type=(AssertionError, decimal.DivisionByZero),
             )
         ]
         failure_test_cases = [

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -171,7 +171,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                     redemption_fee_percent=0.01,
                 ),
                 time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
+                exception_type=(AssertionError, decimal.DivisionByZero),
             ),
             TestCaseCalcInGivenOutFailure(
                 name="trade fee negative",

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -255,7 +255,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                     redemption_fee_percent=0.01,
                 ),
                 time_remaining=StretchedTime(days=365, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
+                exception_type=(AssertionError, decimal.DivisionByZero),
             ),
             TestCaseCalcInGivenOutFailure(
                 name="days remaining > 365",

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -158,37 +158,9 @@ class TestCalcInGivenOut(unittest.TestCase):
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
-                    # share reserves negative
-                    share_reserves=-1,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
                     # share reserves zero
                     share_reserves=0,
                     bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    # bond reserves negative
-                    bond_reserves=-1,
                     share_price=1,
                     init_share_price=1,
                     trade_fee_percent=0.01,

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -91,6 +91,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                     # TODO: test with redemption fees
                     redemption_fee_percent=0.0,
                 )
+                market_state.freeze()  # pylint: disable=no-member # type: ignore
                 time_remaining = StretchedTime(
                     days=365, time_stretch=pricing_model.calc_time_stretch(0.05), normalizing_constant=365
                 )
@@ -111,6 +112,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                     # TODO: test with redemption fees
                     redemption_fee_percent=0.0,
                 )
+                market_state.freeze()  # pylint: disable=no-member # type: ignore
                 time_remaining = StretchedTime(
                     days=365, time_stretch=pricing_model.calc_time_stretch(0.05), normalizing_constant=365
                 )
@@ -126,9 +128,25 @@ class TestCalcInGivenOut(unittest.TestCase):
         """Failure tests for calc_in_given_out"""
         pricing_models: list[PricingModel] = [YieldSpacePricingModel(), HyperdrivePricingModel()]
         # Failure test cases.
+        failure_test_cases_yieldspace_only = [
+            TestCaseCalcInGivenOutFailure(
+                name="share reserves zero",
+                out=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=0,
+                    bond_reserves=1_000_000,
+                    share_price=1,
+                    init_share_price=1,
+                    trade_fee_percent=0.01,
+                    redemption_fee_percent=0.01,
+                ),
+                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
+                exception_type=AssertionError,
+            )
+        ]
         failure_test_cases = [
             TestCaseCalcInGivenOutFailure(
-                # amount negative
+                name="amount negative",
                 out=Quantity(amount=-1, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -142,7 +160,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
-                # amount 0
+                name="amount 0",
                 out=Quantity(amount=0, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -156,27 +174,13 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    # share reserves zero
-                    share_reserves=0,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
+                name="trade fee negative",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
                     share_price=1,
                     init_share_price=1,
-                    # trade fee negative
                     trade_fee_percent=-1,
                     redemption_fee_percent=0.01,
                 ),
@@ -184,6 +188,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="redemption fee negative",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -191,20 +196,19 @@ class TestCalcInGivenOut(unittest.TestCase):
                     share_price=1,
                     init_share_price=1,
                     trade_fee_percent=0.01,
-                    # redemption fee negative
                     redemption_fee_percent=-1,
                 ),
                 time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="trade fee above 1",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
                     share_price=1,
                     init_share_price=1,
-                    # trade fee above 1
                     trade_fee_percent=1.1,
                     redemption_fee_percent=0.01,
                 ),
@@ -212,6 +216,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="redemption fee above 1",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -219,13 +224,13 @@ class TestCalcInGivenOut(unittest.TestCase):
                     share_price=1,
                     init_share_price=1,
                     trade_fee_percent=0.01,
-                    # redemption fee above 1
                     redemption_fee_percent=1.1,
                 ),
                 time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="days remaining negative",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -235,11 +240,11 @@ class TestCalcInGivenOut(unittest.TestCase):
                     trade_fee_percent=1.1,
                     redemption_fee_percent=0.01,
                 ),
-                # days remaining negative
                 time_remaining=StretchedTime(days=-91.25, time_stretch=1.1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="days remaining == 365, will get divide by zero error",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -249,11 +254,11 @@ class TestCalcInGivenOut(unittest.TestCase):
                     trade_fee_percent=0.1,
                     redemption_fee_percent=0.01,
                 ),
-                # days remaining == 365, will get divide by zero error
                 time_remaining=StretchedTime(days=365, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="days remaining > 365",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -263,12 +268,11 @@ class TestCalcInGivenOut(unittest.TestCase):
                     trade_fee_percent=0.1,
                     redemption_fee_percent=0.01,
                 ),
-                # days remaining > 365
                 time_remaining=StretchedTime(days=500, time_stretch=1.1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
-                # amount very high, can't make trade
+                name="amount very high, can't make trade",
                 out=Quantity(amount=10_000_000, unit=TokenType.BASE),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -282,12 +286,12 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=(AssertionError, decimal.InvalidOperation),
             ),
             TestCaseCalcInGivenOutFailure(
+                name="init_share_price 0",
                 out=Quantity(amount=100, unit=TokenType.BASE),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
                     share_price=2,
-                    # init_share_price 0
                     init_share_price=0,
                     trade_fee_percent=0.1,
                     redemption_fee_percent=0.01,
@@ -296,11 +300,11 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="share_price < init_share_price",
                 out=Quantity(amount=100, unit=TokenType.BASE),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    # share_price < init_share_price
                     share_price=1,
                     init_share_price=1.5,
                     trade_fee_percent=0.1,
@@ -310,11 +314,11 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="share_price 0",
                 out=Quantity(amount=100, unit=TokenType.BASE),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    # share_price 0
                     share_price=0,
                     init_share_price=1.5,
                     trade_fee_percent=0.1,
@@ -324,7 +328,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
-                # amount < 1 wei
+                name="amount < 1 wei",
                 out=Quantity(amount=0.5e-18, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -338,37 +342,9 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcInGivenOutFailure(
+                name="reserves waaaay unbalanced",
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
-                    # share_reserves < 1 wei
-                    share_reserves=0.5e-18,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    # bond reserves < 1 wei
-                    bond_reserves=0.5e-18,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    # reserves waaaay unbalanced
                     share_reserves=30_000_000_000,
                     bond_reserves=1,
                     share_price=1,
@@ -380,13 +356,33 @@ class TestCalcInGivenOut(unittest.TestCase):
                 exception_type=AssertionError,
             ),
         ]
-        # Verify that the pricing model raises the expected exception type for
-        # each test case.
+        # Verify that the pricing model raises the expected exception type for each test case.
         for test_number, test_case in enumerate(failure_test_cases):
-            print(f"{test_number=}")
+            print(f"{test_number=}, {test_case.name=}")
             for pricing_model in pricing_models:
                 print(f"{pricing_model.model_name()=}")
                 with self.assertRaises(test_case.exception_type):
+                    test_case.market_state.freeze()  # type: ignore
+                    pricing_model.check_input_assertions(
+                        quantity=test_case.out,
+                        market_state=test_case.market_state,
+                        time_remaining=test_case.time_remaining,
+                    )
+                    trade_result = pricing_model.calc_in_given_out(
+                        out=test_case.out,
+                        market_state=test_case.market_state,
+                        time_remaining=test_case.time_remaining,
+                    )
+                    pricing_model.check_output_assertions(
+                        trade_result=trade_result,
+                    )
+        # check subset of tests in yieldspace only
+        for test_number, test_case in enumerate(failure_test_cases_yieldspace_only):
+            print(f"{test_number=}, {test_case.name=}")
+            for pricing_model in [YieldSpacePricingModel()]:
+                print(f"{pricing_model.model_name()=}")
+                with self.assertRaises(test_case.exception_type):
+                    test_case.market_state.freeze()  # type: ignore
                     pricing_model.check_input_assertions(
                         quantity=test_case.out,
                         market_state=test_case.market_state,

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1510,7 +1510,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     redemption_fee_percent=0.01,
                 ),
                 time_remaining=StretchedTime(days=365, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
+                exception_type=(AssertionError, decimal.DivisionByZero),
             ),
             TestCaseCalcOutGivenInFailure(
                 name="days remaining > 365",

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1401,7 +1401,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
         # Failure test cases.
         failure_test_cases = [
             TestCaseCalcOutGivenInFailure(
-                # amount negative
+                name="amount negative",
                 in_=Quantity(amount=-1, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1415,7 +1415,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
-                # amount 0
+                name="amount 0",
                 in_=Quantity(amount=0, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1429,34 +1429,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
-                in_=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    # share reserves negative
-                    share_reserves=-1,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcOutGivenInFailure(
-                in_=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    # bond reserves negative
-                    bond_reserves=-1,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcOutGivenInFailure(
+                name="trade fee negative",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1466,11 +1439,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     trade_fee_percent=-1,
                     redemption_fee_percent=0.01,
                 ),
-                # trade fee negative
                 time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="redemption fee negative",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1480,11 +1453,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     trade_fee_percent=0.01,
                     redemption_fee_percent=-1,
                 ),
-                # redemption fee negative
                 time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="trade fee above 1",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1494,11 +1467,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     trade_fee_percent=1.1,
                     redemption_fee_percent=0.01,
                 ),
-                # trade fee above 1
                 time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="redemption fee above 1",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1508,11 +1481,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     trade_fee_percent=0.01,
                     redemption_fee_percent=1.1,
                 ),
-                # redemption fee above 1
                 time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="days remaining negative",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1522,11 +1495,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     trade_fee_percent=0.01,
                     redemption_fee_percent=0.01,
                 ),
-                # days remaining negative
                 time_remaining=StretchedTime(days=-91.25, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="days remaining == 365, will get divide by zero error",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1536,11 +1509,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     trade_fee_percent=0.01,
                     redemption_fee_percent=0.01,
                 ),
-                # days remaining == 365, will get divide by zero error
                 time_remaining=StretchedTime(days=365, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="days remaining > 365",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1550,12 +1523,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                     trade_fee_percent=0.01,
                     redemption_fee_percent=0.01,
                 ),
-                # days remaining > 365
                 time_remaining=StretchedTime(days=500, time_stretch=1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
-                # amount very high, can't make trade
+                name="amount very high, can't make trade",
                 in_=Quantity(amount=10_000_000, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1569,12 +1541,12 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 exception_type=(decimal.InvalidOperation, decimal.DivisionByZero),
             ),
             TestCaseCalcOutGivenInFailure(
+                name="init_share_price 0",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
                     share_price=2,
-                    # init_share_price 0
                     init_share_price=0,
                     trade_fee_percent=0.01,
                     redemption_fee_percent=0.01,
@@ -1583,11 +1555,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="share_price < init_share_price",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    # share_price < init_share_price
                     share_price=1,
                     init_share_price=1.5,
                     trade_fee_percent=0.01,
@@ -1597,11 +1569,11 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="share_price 0",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    # share_price 0
                     share_price=0,
                     init_share_price=1.5,
                     trade_fee_percent=0.01,
@@ -1611,7 +1583,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
-                # amount < 1 wei
+                name="amount < 1 wei",
                 in_=Quantity(amount=0.5e-18, unit=TokenType.PT),
                 market_state=MarketState(
                     share_reserves=100_000,
@@ -1625,37 +1597,9 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 exception_type=AssertionError,
             ),
             TestCaseCalcOutGivenInFailure(
+                name="reserves waaaay unbalanced",
                 in_=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
-                    # share_reserves < 1 wei
-                    share_reserves=0.5e-18,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcOutGivenInFailure(
-                in_=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    # bond reserves < 1 wei
-                    bond_reserves=0.5e-18,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcOutGivenInFailure(
-                in_=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    # reserves waaaay unbalanced
                     share_reserves=30_000_000_000,
                     bond_reserves=1,
                     share_price=1,
@@ -1671,7 +1615,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
         # Verify that the pricing model raises the expected exception type for
         # each test case.
         for test_number, test_case in enumerate(failure_test_cases):
-            print(f"{test_number=}")
+            print(f"{test_number=}, {test_case.name=}")
             for pricing_model in pricing_models:
                 print(f"{pricing_model.model_name()=}")
                 with self.assertRaises(test_case.exception_type):

--- a/tests/pricing_models/test_dataclasses.py
+++ b/tests/pricing_models/test_dataclasses.py
@@ -49,6 +49,7 @@ class TestResultCalcInGivenOutSuccessByModel:
 class TestCaseCalcInGivenOutFailure:
     """Dataclass for calc_in_given_out test cases"""
 
+    name: str
     out: Quantity
     market_state: MarketState
     time_remaining: StretchedTime
@@ -113,6 +114,7 @@ class TestResultCalcOutGivenInSuccessByModel:
 class TestCaseCalcOutGivenInFailure:
     """Dataclass for calc_out_given_in failure test cases"""
 
+    name: str
     in_: Quantity
     market_state: MarketState
     time_remaining: StretchedTime

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -11,10 +11,13 @@ import pathlib
 import ast
 import tempfile
 from contextlib import redirect_stdout, redirect_stderr
+import logging
 
 import astunparse
 from IPython.core.inputtransformer2 import TransformerManager
 import nbformat
+
+import elfpy.utils.outputs as output_utils  # utilities for file outputs
 
 
 class TestNotebook(unittest.TestCase):
@@ -24,6 +27,7 @@ class TestNotebook(unittest.TestCase):
         """Tests notebooks in the `examples/notebooks` folder to ensure that they run without error"""
         # pylint: disable=too-many-locals
         # pylint: disable=too-many-branches
+        output_utils.setup_logging(log_filename=".logging/test_notebooks.log", log_level=logging.DEBUG)
         isp = TransformerManager()  # module for converting jupyter cell into source code
         notebook_location = os.path.join(
             os.path.dirname(pathlib.Path(__file__).parent.resolve()),
@@ -32,6 +36,7 @@ class TestNotebook(unittest.TestCase):
         for file in os.listdir(notebook_location):
             if not file.endswith(".ipynb"):
                 continue
+            logging.debug("Testing notebook: %s", file)
             # Read the notebook cell by cell, grab the code & add it to a string
             notebook = nbformat.read(os.path.join(notebook_location, file), as_version=4)
             file_source = ""


### PR DESCRIPTION
* add precision check when market reserves are updated in `apply_delta` which is called in `update_market` which is called in `trade_and_update` at the end of every trade
* remove precision checks from pricing models
* remove tests for market reserves from `test_calc_in_given_out`: share reserves < 1 wei, bond reserves < 1 wei
* add failure test for share_reserves==0 in test_calc_in_given_out checked only for yieldspace (it's valid in hyperdrive 😈)
* remove tests for market reserves from `test_calc_out_given_in`: negative share reserves, negative base reserves, share reserves < 1 wei, bond reserves < 1 wei
* add names to `test_calc_in_given_out` and `test_calc_out_given_in` failure test cases so you don't have to manually count code blocks to find test case 14 (copied from existing code comments)
* make checks for time less strict to allow time=1.0 and eliminate `TODO: convert this to a check for 1>=time and fix tests as necessary`
* add basic logging to `test_notebook` so I can see which notebook is failing