### PR TITLE
check inputs in liquidity trades

### DIFF
--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -472,6 +472,13 @@ class Market:
             rate = 0
         else:
             rate = self.apr
+        # sanity check inputs
+        self.pricing_model.check_input_assertions(
+            quantity=Quantity(amount=trade_amount, unit=TokenType.PT),  # temporary Quantity object just for this check
+            market_state=self.market_state,
+            time_remaining=self.position_duration,
+        )
+        # perform the trade
         lp_out, d_base_reserves, d_token_reserves = self.pricing_model.calc_lp_out_given_tokens_in(
             d_base=trade_amount,
             rate=rate,
@@ -496,6 +503,13 @@ class Market:
         trade_amount: float,
     ) -> tuple[MarketDeltas, Wallet]:
         """Computes new deltas for bond & share reserves after liquidity is removed"""
+        # sanity check inputs
+        self.pricing_model.check_input_assertions(
+            quantity=Quantity(amount=trade_amount, unit=TokenType.PT),  # temporary Quantity object just for this check
+            market_state=self.market_state,
+            time_remaining=self.position_duration,
+        )
+        # perform the trade
         lp_in, d_base_reserves, d_token_reserves = self.pricing_model.calc_tokens_out_given_lp_in(
             lp_in=trade_amount,
             rate=self.apr,

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -455,15 +455,15 @@ class PricingModel(ABC):
             "pricing_models.check_input_assertions: ERROR: "
             f"expected quantity.amount >= {WEI}, not {quantity.amount}!"
         )
-        assert market_state.share_reserves >= WEI, (
+        assert market_state.share_reserves >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
             f"expected share_reserves >= {WEI}, not {market_state.share_reserves}!"
         )
-        assert market_state.bond_reserves >= WEI or market_state.bond_reserves == 0, (
+        assert market_state.bond_reserves >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
             f"expected bond_reserves >= {WEI} or bond_reserves == 0, not {market_state.bond_reserves}!"
         )
-        assert market_state.share_price >= market_state.init_share_price >= 1, (
+        assert market_state.share_price >= 0, (
             f"pricing_models.check_input_assertions: ERROR: "
             f"expected share_price >= init_share_price >= 1, not share_price={market_state.share_price} "
             f"and init_share_price={market_state.init_share_price}!"
@@ -481,13 +481,11 @@ class PricingModel(ABC):
             "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 >= redemption_fee_percent >= 0, not {market_state.redemption_fee_percent}!"
         )
-        # TODO: convert this to a check for 1>=time and fix tests as necessary
-        # issue #57
-        assert 1 > time_remaining.stretched_time >= 0, (
+        assert 1 >= time_remaining.stretched_time >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 > time_remaining.stretched_time >= 0, not {time_remaining.stretched_time}!"
         )
-        assert 1 > time_remaining.normalized_time >= 0, (
+        assert 1 >= time_remaining.normalized_time >= 0, (
             "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
         )

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -463,10 +463,13 @@ class PricingModel(ABC):
             "pricing_models.check_input_assertions: ERROR: "
             f"expected bond_reserves >= {WEI} or bond_reserves == 0, not {market_state.bond_reserves}!"
         )
-        assert market_state.share_price >= 0, (
+        assert market_state.share_price > 0, (
             f"pricing_models.check_input_assertions: ERROR: "
-            f"expected share_price >= init_share_price >= 1, not share_price={market_state.share_price} "
-            f"and init_share_price={market_state.init_share_price}!"
+            f"expected share_price > 0, not share_price={market_state.share_price}"
+        )
+        assert market_state.init_share_price > 0, (
+            f"pricing_models.check_input_assertions: ERROR: "
+            f"expected init_share_price > 0, not share_price={market_state.init_share_price}"
         )
         reserves_difference = abs(market_state.share_reserves * market_state.share_price - market_state.bond_reserves)
         assert reserves_difference < MAX_RESERVES_DIFFERENCE, (

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -463,13 +463,13 @@ class PricingModel(ABC):
             "pricing_models.check_input_assertions: ERROR: "
             f"expected bond_reserves >= {WEI} or bond_reserves == 0, not {market_state.bond_reserves}!"
         )
-        assert market_state.share_price > 0, (
+        assert market_state.share_price >= market_state.init_share_price, (
             f"pricing_models.check_input_assertions: ERROR: "
-            f"expected share_price > 0, not share_price={market_state.share_price}"
+            f"expected share_price >= {market_state.init_share_price}, not share_price={market_state.share_price}"
         )
-        assert market_state.init_share_price > 0, (
+        assert market_state.init_share_price >= 1, (
             f"pricing_models.check_input_assertions: ERROR: "
-            f"expected init_share_price > 0, not share_price={market_state.init_share_price}"
+            f"expected init_share_price >= 1, not share_price={market_state.init_share_price}"
         )
         reserves_difference = abs(market_state.share_reserves * market_state.share_price - market_state.bond_reserves)
         assert reserves_difference < MAX_RESERVES_DIFFERENCE, (

--- a/src/elfpy/pricing_models/base.py
+++ b/src/elfpy/pricing_models/base.py
@@ -474,18 +474,22 @@ class PricingModel(ABC):
             f"expected reserves_difference < {MAX_RESERVES_DIFFERENCE}, not {reserves_difference}!"
         )
         assert 1 >= market_state.trade_fee_percent >= 0, (
-            "pricing_models.calc_in_given_out: ERROR: "
+            "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 >= trade_fee_percent >= 0, not {market_state.trade_fee_percent}!"
         )
         assert 1 >= market_state.redemption_fee_percent >= 0, (
-            "pricing_models.calc_in_given_out: ERROR: "
+            "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 >= redemption_fee_percent >= 0, not {market_state.redemption_fee_percent}!"
         )
         # TODO: convert this to a check for 1>=time and fix tests as necessary
         # issue #57
         assert 1 > time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_in_given_out: ERROR: "
+            "pricing_models.check_input_assertions: ERROR: "
             f"expected 1 > time_remaining.stretched_time >= 0, not {time_remaining.stretched_time}!"
+        )
+        assert 1 > time_remaining.normalized_time >= 0, (
+            "pricing_models.check_input_assertions: ERROR: "
+            f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
         )
 
     # TODO: Add checks for TradeResult's other outputs.

--- a/src/elfpy/pricing_models/hyperdrive.py
+++ b/src/elfpy/pricing_models/hyperdrive.py
@@ -127,6 +127,7 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
                 f"Expected out.unit to be {TokenType.BASE} or {TokenType.PT}, not {out.unit}!"
             )
 
+        print(f"calling calc_in_given_out with {out_amount} {out.unit} {time_remaining} and {market_state}")
         # Trade the bonds that haven't matured on the YieldSpace curve.
         curve = super().calc_in_given_out(
             out=Quantity(amount=float(out_amount * normalized_time), unit=out.unit),

--- a/src/elfpy/pricing_models/hyperdrive.py
+++ b/src/elfpy/pricing_models/hyperdrive.py
@@ -126,7 +126,6 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
                 "pricing_models.calc_in_given_out: ERROR: "
                 f"Expected out.unit to be {TokenType.BASE} or {TokenType.PT}, not {out.unit}!"
             )
-
         # Trade the bonds that haven't matured on the YieldSpace curve.
         curve = super().calc_in_given_out(
             out=Quantity(amount=float(out_amount * normalized_time), unit=out.unit),

--- a/src/elfpy/pricing_models/hyperdrive.py
+++ b/src/elfpy/pricing_models/hyperdrive.py
@@ -127,7 +127,6 @@ class HyperdrivePricingModel(YieldSpacePricingModel):
                 f"Expected out.unit to be {TokenType.BASE} or {TokenType.PT}, not {out.unit}!"
             )
 
-        print(f"calling calc_in_given_out with {out_amount} {out.unit} {time_remaining} and {market_state}")
         # Trade the bonds that haven't matured on the YieldSpace curve.
         curve = super().calc_in_given_out(
             out=Quantity(amount=float(out_amount * normalized_time), unit=out.unit),

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -291,7 +291,6 @@ class YieldSpacePricingModel(PricingModel):
         )
         out_amount = Decimal(out.amount)
         trade_fee_percent = Decimal(market_state.trade_fee_percent)
-        print(f"executing calc_in_given_out with {share_reserves=} {bond_reserves=} {spot_price=} {out_amount=}")
         # We precompute the YieldSpace constant k using the current reserves and
         # share price:
         #

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -52,37 +52,6 @@ class YieldSpacePricingModel(PricingModel):
             y = \frac{(z + \Delta z)(\mu \cdot (\frac{1}{1 + r \cdot t(d)})^{\frac{1}{\tau(d_b)}} - c)}{2}
 
         """
-        assert d_base > 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected d_base > 0, not {d_base}!"
-        assert market_state.share_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR:  "
-            f"Expected share_reserves >= 0, not {market_state.share_reserves}!"
-        )
-        assert market_state.bond_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected bond_reserves >= 0, not {market_state.bond_reserves}!"
-        )
-        assert market_state.base_buffer >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected base_buffer >= 0, not {market_state.base_buffer}!"
-        )
-        assert market_state.lp_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected lp_reserves >= 0, not {market_state.lp_reserves}!"
-        )
-        assert rate >= 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected rate >= 0, not {rate}!"
-        assert 1 >= time_remaining.normalized_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"expected 1 >= time_remaining >= 0, not {time_remaining.normalized_time}!"
-        )
-        assert time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"expected stretched_time_remaining >= 0, not {time_remaining.stretched_time}!"
-        )
-        assert market_state.share_price >= market_state.init_share_price >= 1, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            "expected share_price >= init_share_price >= 1, not "
-            f"share_price={market_state.share_price} and init_share_price={market_state.init_share_price}!"
-        )
         d_shares = d_base / market_state.share_price
         if market_state.share_reserves > 0:  # normal case where we have some share reserves
             # TODO: We need to update these LP calculations to address the LP
@@ -159,39 +128,6 @@ class YieldSpacePricingModel(PricingModel):
             y = \frac{(z - \Delta z)(\mu \cdot (\frac{1}{1 + r \cdot t(d)})^{\frac{1}{\tau(d_b)}} - c)}{2}
 
         """
-        assert d_base > 0, f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected d_base > 0, not {d_base}!"
-        assert market_state.share_reserves >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected share_reserves >= 0, not {market_state.share_reserves}!"
-        )
-        assert market_state.bond_reserves >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected bond_reserves >= 0, not {market_state.bond_reserves}!"
-        )
-        assert market_state.base_buffer >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected base_buffer >= 0, not {market_state.base_buffer}!"
-        )
-        assert market_state.lp_reserves >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"Expected lp_reserves >= 0, not {market_state.lp_reserves}!"
-        )
-        assert rate >= 0, f"pricing_models.calc_lp_in_given_tokens_out: ERROR: expected rate >= 0, not {rate}!"
-        # TODO: convert this to a check for 1>=time and fix tests as necessary
-        # issue #57
-        assert 1 > time_remaining.normalized_time >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"expected 1 > time_remaining >= 0, not {time_remaining.normalized_time}!"
-        )
-        assert time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            f"expected stretched_time_remaining >= 0, not {time_remaining.stretched_time}!"
-        )
-        assert market_state.share_price >= market_state.init_share_price >= 1, (
-            "pricing_models.calc_lp_in_given_tokens_out: ERROR: "
-            "expected share_price >= init_share_price >= 1, not "
-            f"share_price={market_state.share_price}, and init_share_price={market_state.init_share_price}"
-        )
         d_shares = d_base / market_state.share_price
         lp_in = (d_shares * market_state.lp_reserves) / (
             market_state.share_reserves - market_state.base_buffer / market_state.share_price
@@ -215,40 +151,6 @@ class YieldSpacePricingModel(PricingModel):
 
         .. todo:: add test for this function; improve function documentation w/ parameters, returns, and equations used
         """
-        assert lp_in > 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected lp_in > 0, not {lp_in}!"
-        assert market_state.share_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected share_reserves >= 0, not {market_state.share_reserves}!"
-        )
-        assert market_state.bond_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected bond_reserves >= 0, not {market_state.bond_reserves}!"
-        )
-        # TODO: These asserts should check for 0 -- the buffers should never go below 0
-        # We think that this is happening due to an rounding error, based on the size of the difference
-        # issue #146
-        assert market_state.base_buffer >= -1e-8, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected base_buffer >= 0, not {market_state.base_buffer}!"
-        )
-        assert market_state.lp_reserves >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected lp_reserves >= 0, not {market_state.lp_reserves}!"
-        )
-        assert rate >= 0, f"pricing_models.calc_lp_out_given_tokens_in: ERROR: expected rate >= 0, not {rate}!"
-        assert 1 >= time_remaining.normalized_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"Expected 1 >= time_remaining >= 0, not {time_remaining.normalized_time}!"
-        )
-        assert time_remaining.stretched_time >= 0, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            f"expected stretched_time_remaining >= 0, not {time_remaining.stretched_time}!"
-        )
-        assert market_state.share_price >= market_state.init_share_price >= 1, (
-            "pricing_models.calc_lp_out_given_tokens_in: ERROR: "
-            "expected share_price >= init_share_price >= 1, not "
-            f"share_price={market_state.share_price}, and init_share_price={market_state.init_share_price}"
-        )
         d_base = (
             market_state.share_price
             * (market_state.share_reserves - market_state.base_buffer)

--- a/src/elfpy/pricing_models/yieldspace.py
+++ b/src/elfpy/pricing_models/yieldspace.py
@@ -291,6 +291,7 @@ class YieldSpacePricingModel(PricingModel):
         )
         out_amount = Decimal(out.amount)
         trade_fee_percent = Decimal(market_state.trade_fee_percent)
+        print(f"executing calc_in_given_out with {share_reserves=} {bond_reserves=} {spot_price=} {out_amount=}")
         # We precompute the YieldSpace constant k using the current reserves and
         # share price:
         #

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -6,7 +6,6 @@ from functools import wraps
 from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
 from enum import Enum
-import logging
 import json
 
 import numpy as np
@@ -62,13 +61,6 @@ def freezable(frozen: bool = False, no_new_attribs: bool = False) -> Type:
         return FrozenClass
 
     return decorator
-
-
-# The maximum allowed precision error.
-# This value was selected based on one test not passing without it.
-# apply_delta() below checks if reserves are negative within the threshold,
-# and sets them to 0 if so.
-PRECISION_THRESHOLD = 1e-9
 
 
 class TokenType(Enum):
@@ -278,17 +270,6 @@ class MarketState:
         self.bond_buffer += delta.d_bond_buffer
         self.lp_reserves += delta.d_lp_reserves
         self.share_price += delta.d_share_price
-        for key, value in self.__dict__.items():
-            if 0 > value > -PRECISION_THRESHOLD:
-                logging.debug(
-                    ("%s=%s is negative within PRECISION_THRESHOLD=%f, setting it to 0"),
-                    key,
-                    value,
-                    PRECISION_THRESHOLD,
-                )
-                setattr(self, key, 0)
-            else:
-                assert value >= 0, "MarketState values must be non-negative"
 
         # this is an imperfect solution to rounding errors, but it works for now
         # ideally we'd find a more thorough solution than just catching errors
@@ -304,7 +285,9 @@ class MarketState:
                 )
                 setattr(self, key, 0)
             else:
-                assert value >= 0, f"MarketState values must be non-negative. Error on {key} = {value}"
+                assert (
+                    value > -PRECISION_THRESHOLD
+                ), f"MarketState values must be > {-PRECISION_THRESHOLD}. Error on {key} = {value}"
 
     def copy(self) -> MarketState:
         """Returns a new copy of self"""

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -1238,4 +1238,4 @@ pt_in_test_cases_hyperdrive_only = [
     ),  # end of test one
 ]
 
-# TODO: test the success cases
+# TODO: test the success cases, #204

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -315,6 +315,20 @@ class TestCalcInGivenOut(unittest.TestCase):
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
+                    # share_price < init_share_price
+                    share_price=1,
+                    init_share_price=1.5,
+                    trade_fee_percent=0.1,
+                    redemption_fee_percent=0.01,
+                ),
+                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcInGivenOutFailure(
+                out=Quantity(amount=100, unit=TokenType.BASE),
+                market_state=MarketState(
+                    share_reserves=100_000,
+                    bond_reserves=1_000_000,
                     # share_price 0
                     share_price=0,
                     init_share_price=1.5,

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -1203,10 +1203,10 @@ pt_in_test_cases_hyperdrive_only = [
                 share_price=1,  # share price of the LP in the yield source
                 init_share_price=1,  # original share price pool started
                 trade_fee_percent=0.01,  # fee percent (normally 10%)
-                redemption_fee_percent=0.01,  # fee percent (normally 10%)
+                redemption_fee_percent=0.00,  # fee percent (normally 10%)
             ),
             days_remaining=182.5,  # 6 months remaining
-            time_stretch_apy=1.1,  # APY of 5% used to calculate time_stretch
+            time_stretch_apy=0.05,  # APY of 5% used to calculate time_stretch
         ),
         # From the input, we have the following values:
         #
@@ -1214,49 +1214,42 @@ pt_in_test_cases_hyperdrive_only = [
         #   z = 50
         #   y = 999_950
         #
-        #   t_stretch = 22.1868770168519182502689135891
+        #   t_stretch = 3.09396 / (0.02789 * apr_percent)
+        #             = 3.09396 / (0.02789 * 0.05 * 100)
+        #             = 22.1868770168519182502689135891
         #
-        #   tau = d / (365 * t_stretch)
-        #     = 182.5 / (365 * 22.1868770168519182502689135891)
-        #     = 0.022535844031597044
+        #   tau = 365 / (365 * t_stretch) * always use FULL TAU for hyperdrive
+        #     = 1 / 22.1868770168519182502689135891
+        #     = 0.045071688063194094
         #
-        #   1 - tau = 0.977464155968403
+        #   1 - tau = 0.9549283119368059
         #
         #   k = (c / mu) * (mu * z) **(1 - tau) + (2 * y + c * z)**(1 - tau)
-        #     = (1 / 1) * (1 * 0) ** 0.977464155968403 +
-        #           (2 * 1_000_000 + 1 * 0) ** 0.977464155968403
-        #     = 1_442_218.1821553102
+        #     = (1 / 1) * (1 * 0) ** 0.9549283119368059 +
+        #           (2 * 1_000_000 + 1 * 0) ** 0.9549283119368059
+        #     = 1_039_996.6424696837
         #
-        #   p = ((2 * y + c * z) / (mu * z)) ** tau
-        #     = ((2 * 999_950 + 1 * 50) / (1 * 50)) ** 0.022535844031597044
-        #     = 1.2697290664423557
+        #   p = ((2 * y + c * z) / (mu * z)) ** -tau
+        #     = ((2 * 999_950 + 1 * 50) / (1 * 50)) ** -0.045071688063194094
+        #     = 0.6202658587589548
         TestResultCalcInGivenOutSuccessByModel(
             hyperdrive=TestResultCalcInGivenOutSuccess(
-                # spot_price = p * delta_y * t + delta_y * (1 - t)
-                # spot_price = 1.2697290664423557 * 50 * 0.5 + 50 * 0.5
-                # spot_price = 31.743226661058895 + 25
-                # spot_price = 56.743226661058895
-                without_fee_or_slippage=56.743226661058895,
-                # yield space equation (for hyperdrive multiply d_z by t):
-                # k = (c / mu) * (mu * (z + d_z))**(1 - tau) + (2y + cz - d_y')**(1 - tau)
-                # dy' = 2y + c*z - (k - (c / mu) * (mu * (z + d_z))**(1 - tau))**(1 / (1 - tau))
-                #
-                # note: use delta_z * t to phase the curve part out, and add delta_z * (1 - t)
-                # to phase the flat part in over the length of the term:
-                #
-                # dy' = 2*y + c*z - (k - (c / u) * (u * (z + delta_z*t))**(1 - tau_full))**(1 / (1 - tau_full))
-                #       + c * delta_z * (1 - t)
-                # dy' = 2000150.0 + 199925.0 - (1255966.2592326764 - 1.3333333333333333
-                #       * (1.5 * (99962.5 + 50.0*0.25))**(0.9549283119368059))**(1.0471990279267966)
-                #       + 2 * 50.0 * 0.75
-                without_fee=97.14941590232775,
-                # fee = ((1 / p) - 1) * phi * c * d_z
-                # fee = (1.1286948282596905 - 1) * 0.01 * 2 * 50.0
-                fee=0.25397154625167895,
-                with_fee=102.79448674223747,
+                # without_fee_or_slippage = p * delta_y * t + delta_y * (1 - t)
+                # without_fee_or_slippage = 0.6202658587589548 * 100 * 0.5 + 100 * 0.5
+                # without_fee_or_slippage = 31.01329293794774 + 50
+                # without_fee_or_slippage = 81.01329293794774
+                without_fee_or_slippage=81.01329293794774,
+                # t_d=0.5
+                # tau=0.02253584403159705
+                # 1-tau=0.977464155968403
+                # t_stretch=22.186877016851916
+                # spot_price=0.6202658587589547
+                # in_base=81.38288223597203
+                # in_pt=134.41541713429615
+                without_fee=81.38288223597203,
+                fee=0.18986707062052266,
+                with_fee=81.57274930659256,
             ),
         ),
     ),  # end of test one
 ]
-
-# TODO: test the success cases, #204

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -173,20 +173,6 @@ class TestCalcInGivenOut(unittest.TestCase):
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
                 market_state=MarketState(
-                    # share reserves zero
-                    share_reserves=0,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
                     share_reserves=100_000,
                     # bond reserves negative
                     bond_reserves=-1,
@@ -280,7 +266,7 @@ class TestCalcInGivenOut(unittest.TestCase):
                 ),
                 # days remaining == 365, will get divide by zero error
                 time_remaining=StretchedTime(days=365, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
+                exception_type=(AssertionError, decimal.DivisionByZero),
             ),
             TestCaseCalcInGivenOutFailure(
                 out=Quantity(amount=100, unit=TokenType.PT),
@@ -329,20 +315,6 @@ class TestCalcInGivenOut(unittest.TestCase):
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    # share_price < init_share_price
-                    share_price=1,
-                    init_share_price=1.5,
-                    trade_fee_percent=0.1,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.BASE),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    bond_reserves=1_000_000,
                     # share_price 0
                     share_price=0,
                     init_share_price=1.5,
@@ -358,34 +330,6 @@ class TestCalcInGivenOut(unittest.TestCase):
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    # share_reserves < 1 wei
-                    share_reserves=0.5e-18,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    # bond reserves < 1 wei
-                    bond_reserves=0.5e-18,
                     share_price=1,
                     init_share_price=1,
                     trade_fee_percent=0.01,

--- a/tests/pricing_models/test_calc_in_given_out.py
+++ b/tests/pricing_models/test_calc_in_given_out.py
@@ -127,22 +127,6 @@ class TestCalcInGivenOut(unittest.TestCase):
         """Failure tests for calc_in_given_out"""
         pricing_models: list[PricingModel] = [YieldSpacePricingModel(), HyperdrivePricingModel()]
         # Failure test cases.
-        failure_test_cases_yieldpsace_only = [
-            TestCaseCalcInGivenOutFailure(
-                out=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    # share reserves zero
-                    share_reserves=0,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
-                exception_type=(AssertionError, decimal.DivisionByZero),
-            )
-        ]
         failure_test_cases = [
             TestCaseCalcInGivenOutFailure(
                 # amount negative
@@ -368,6 +352,22 @@ class TestCalcInGivenOut(unittest.TestCase):
                 time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
                 exception_type=AssertionError,
             ),
+        ]
+        failure_test_cases_yieldpsace_only = [
+            TestCaseCalcInGivenOutFailure(
+                out=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    # share reserves zero
+                    share_reserves=0,
+                    bond_reserves=1_000_000,
+                    share_price=1,
+                    init_share_price=1,
+                    trade_fee_percent=0.01,
+                    redemption_fee_percent=0.01,
+                ),
+                time_remaining=StretchedTime(days=91.25, time_stretch=1.1, normalizing_constant=365),
+                exception_type=(AssertionError, decimal.DivisionByZero),
+            )
         ]
         # Verify that the pricing model raises the expected exception type for
         # each test case.

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1587,6 +1587,20 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
+                    # share_price < init_share_price
+                    share_price=1,
+                    init_share_price=1.5,
+                    trade_fee_percent=0.01,
+                    redemption_fee_percent=0.01,
+                ),
+                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
+                exception_type=AssertionError,
+            ),
+            TestCaseCalcOutGivenInFailure(
+                in_=Quantity(amount=100, unit=TokenType.PT),
+                market_state=MarketState(
+                    share_reserves=100_000,
+                    bond_reserves=1_000_000,
                     # share_price 0
                     share_price=0,
                     init_share_price=1.5,

--- a/tests/pricing_models/test_calc_out_given_in.py
+++ b/tests/pricing_models/test_calc_out_given_in.py
@@ -1538,7 +1538,7 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 ),
                 # days remaining == 365, will get divide by zero error
                 time_remaining=StretchedTime(days=365, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
+                exception_type=(AssertionError, decimal.DivisionByZero),
             ),
             TestCaseCalcOutGivenInFailure(
                 in_=Quantity(amount=100, unit=TokenType.PT),
@@ -1587,20 +1587,6 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    # share_price < init_share_price
-                    share_price=1,
-                    init_share_price=1.5,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcOutGivenInFailure(
-                in_=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    bond_reserves=1_000_000,
                     # share_price 0
                     share_price=0,
                     init_share_price=1.5,
@@ -1616,34 +1602,6 @@ class TestCalcOutGivenIn(unittest.TestCase):
                 market_state=MarketState(
                     share_reserves=100_000,
                     bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcOutGivenInFailure(
-                in_=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    # share_reserves < 1 wei
-                    share_reserves=0.5e-18,
-                    bond_reserves=1_000_000,
-                    share_price=1,
-                    init_share_price=1,
-                    trade_fee_percent=0.01,
-                    redemption_fee_percent=0.01,
-                ),
-                time_remaining=StretchedTime(days=91.25, time_stretch=1, normalizing_constant=365),
-                exception_type=AssertionError,
-            ),
-            TestCaseCalcOutGivenInFailure(
-                in_=Quantity(amount=100, unit=TokenType.PT),
-                market_state=MarketState(
-                    share_reserves=100_000,
-                    # bond reserves < 1 wei
-                    bond_reserves=0.5e-18,
                     share_price=1,
                     init_share_price=1,
                     trade_fee_percent=0.01,

--- a/tests/pricing_models/test_dataclasses.py
+++ b/tests/pricing_models/test_dataclasses.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Type
+from typing import Type, Optional
 
 from elfpy.types import MarketState, Quantity, StretchedTime
 
@@ -39,8 +39,8 @@ class TestResultCalcInGivenOutSuccessByModel:
         """Get object attribute referenced by `key`"""
         return getattr(self, key)
 
-    yieldspace: TestResultCalcInGivenOutSuccess
-    hyperdrive: TestResultCalcInGivenOutSuccess
+    yieldspace: Optional[TestResultCalcInGivenOutSuccess] = None
+    hyperdrive: Optional[TestResultCalcInGivenOutSuccess] = None
 
     __test__ = False  # pytest: don't test this class
 


### PR DESCRIPTION
1. add check inputs in liquidity trades (add liquidity and remove liquidity)
2. this causes a bunch of failures, so fix this by loosening asserts. which ones?
```
checks loosened:
bond > 1 wei => bond >= 0
shares > 1 wei => shares >= 0
allow time == 1 for norm and stretched:
1 > stretched_time >= 0
=> 1 >= stretched_time >= 0
=> 1 >= norm_time >= 0
```
why is this okay?
the first two check that bond and share reserves are >=0, a value lower than previous by 1e-18 (1 WEI). this is well within our precision threshold. it's needed because in the percision threshold check, we take a negative value within the threshold and set it to 0, which would fail the `> 1 wei` check.
allowing time == 1 is needed for trades on day 0 and had been planned to be added. this removes the TODO for it.
3. remove asserts from `yieldspace.py` because they're all fully covered in `check_input_assertions` now
4. make assert in `types.py` more descriptive
5. fix tests in test_calc_in/out_given_out/in
remove 2 tests for `reserves < 1 wei` no longer needed, since we don't check for it, as above
move `share_reserves == 0` into a new category that fails in yieldspace only
this passes in hyperdrive because before executing the trade, hyperdrive adds the matured portion to share reserves, so there's now something to execute against
6. add new `share_reserves == 0` as a success case for hyperdrive only
7. this requires adding model-specific testing
8. this requires changing the `TestResultCalcInGivenOutSuccessByModel` dataclass to make the model-specific test cases optional