### PR TITLE
propagates changes to remove open_share_price argument from create_ag…

### DIFF
--- a/examples/example_main.py
+++ b/examples/example_main.py
@@ -48,7 +48,6 @@ class CustomShorter(Agent):
                         self.create_agent_action(
                             action_type=MarketActionType.CLOSE_SHORT,
                             trade_amount=self.pt_to_short,
-                            open_share_price=1.0,
                         )
                     )
         return action_list

--- a/examples/notebooks/hyperdrive.ipynb
+++ b/examples/notebooks/hyperdrive.ipynb
@@ -209,7 +209,7 @@
         "            trade_amount = self.wallet.shorts[short_time].balance # close the full trade\n",
         "            open_share_price = self.wallet.shorts[short_time].open_share_price\n",
         "            action_list = [\n",
-        "                self.create_agent_action(action_type=action_type, trade_amount=trade_amount, mint_time=short_time, open_share_price=open_share_price),\n",
+        "                self.create_agent_action(action_type=action_type, trade_amount=trade_amount, mint_time=short_time),\n",
         "            ]\n",
         "        elif action_type == MarketActionType.CLOSE_LONG:\n",
         "            long_time = self.rng.choice(list(self.wallet.longs))\n",

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -46,7 +46,7 @@ class Agent:
         self.name = str(self).split(" ", maxsplit=1)[0][len("<elfpy.policies.") : -len(".Policy")]
 
     def create_agent_action(
-        self, action_type: MarketActionType, trade_amount: float, mint_time: float = 0, open_share_price=0.0
+        self, action_type: MarketActionType, trade_amount: float, mint_time: float = 0
     ) -> MarketAction:
         r"""Creates and returns a MarketAction object which represents a trade that this agent can make
 
@@ -64,15 +64,26 @@ class Agent:
         MarketAction
             The MarketAction object that contains the details about the action to execute in the market
         """
-        agent_action = MarketAction(
-            # these two variables are required to be set by the strategy
-            action_type=action_type,
-            trade_amount=trade_amount,
-            # next two variables are set automatically by the basic agent class
-            wallet_address=self.wallet.address,
-            mint_time=mint_time,
-            open_share_price=open_share_price,
-        )
+        if action_type == MarketActionType.CLOSE_SHORT:
+            open_share_price = self.wallet.shorts[mint_time].open_share_price
+            agent_action = MarketAction(
+                # these two variables are required to be set by the strategy
+                action_type=action_type,
+                trade_amount=trade_amount,
+                # next two variables are set automatically by the basic agent class
+                wallet_address=self.wallet.address,
+                mint_time=mint_time,
+                open_share_price=open_share_price,
+            )
+        else:
+            agent_action = MarketAction(
+                # these two variables are required to be set by the strategy
+                action_type=action_type,
+                trade_amount=trade_amount,
+                # next two variables are set automatically by the basic agent class
+                wallet_address=self.wallet.address,
+                mint_time=mint_time,
+            )
         return agent_action
 
     def action(self, market: Market) -> list[MarketAction]:
@@ -348,7 +359,6 @@ class Agent:
                         action_type=MarketActionType.CLOSE_SHORT,
                         trade_amount=short.balance,
                         mint_time=mint_time,
-                        open_share_price=short.open_share_price,
                     )
                 )
         if self.wallet.lp_tokens > 0:

--- a/src/elfpy/agent.py
+++ b/src/elfpy/agent.py
@@ -66,24 +66,17 @@ class Agent:
         """
         if action_type == MarketActionType.CLOSE_SHORT:
             open_share_price = self.wallet.shorts[mint_time].open_share_price
-            agent_action = MarketAction(
-                # these two variables are required to be set by the strategy
-                action_type=action_type,
-                trade_amount=trade_amount,
-                # next two variables are set automatically by the basic agent class
-                wallet_address=self.wallet.address,
-                mint_time=mint_time,
-                open_share_price=open_share_price,
-            )
         else:
-            agent_action = MarketAction(
-                # these two variables are required to be set by the strategy
-                action_type=action_type,
-                trade_amount=trade_amount,
-                # next two variables are set automatically by the basic agent class
-                wallet_address=self.wallet.address,
-                mint_time=mint_time,
-            )
+            open_share_price = None
+        agent_action = MarketAction(
+            # these two variables are required to be set by the strategy
+            action_type=action_type,
+            trade_amount=trade_amount,
+            # next two variables are set automatically by the basic agent class
+            wallet_address=self.wallet.address,
+            mint_time=mint_time,
+            open_share_price=open_share_price,
+        )
         return agent_action
 
     def action(self, market: Market) -> list[MarketAction]:

--- a/src/elfpy/markets.py
+++ b/src/elfpy/markets.py
@@ -141,6 +141,9 @@ class Market:
                 trade_amount=agent_action.trade_amount,  # in bonds: that's the thing you want to short
             )
         elif agent_action.action_type == MarketActionType.CLOSE_SHORT:  # buy PT to close short
+            assert (
+                agent_action.open_share_price is not None
+            ), "ERROR: agent_action.open_share_price must be provided when closing a short"
             market_deltas, agent_deltas = self.close_short(
                 wallet_address=agent_action.wallet_address,
                 trade_amount=agent_action.trade_amount,  # in bonds: that's the thing you owe, and need to buy back

--- a/src/elfpy/types.py
+++ b/src/elfpy/types.py
@@ -146,7 +146,7 @@ class MarketAction:
     # wallet_address is always set automatically by the basic agent class
     wallet_address: int
     # the share price when a short was created
-    open_share_price: float = 1
+    open_share_price: Optional[float] = None
     # mint time is set only for trades that act on existing positions (close long or close short)
     mint_time: float = 0
 


### PR DESCRIPTION
create_agent_action no longer has an open_share_price argument. If the action is close short then it is derived from the share price.
MarketAction has a better default for open_share_price, and only requires it on close_short
if it is not provided, market.close_short fails instead of propagating a default value
