### PR TITLE
Refactor Checkpointing Logic

### DIFF
--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -5,7 +5,7 @@ import copy
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Union
+from typing import Literal, Union
 
 import numpy as np
 
@@ -27,6 +27,12 @@ class Checkpoint:
     period that has LP or trading activity. The checkpoints contain the starting share price from
     the checkpoint as well as aggregate volume values.
     """
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        return setattr(self, key, value)
 
     share_price: float = field(default=0.0)
     long_base_volume: float = field(default=0.0)
@@ -64,6 +70,12 @@ class MarketState(base_market.BaseMarketState):
     redemption_fee_percent : float
         A flat fee applied to the output.  Not used in this equation for Yieldspace.
     """
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        return setattr(self, key, value)
 
     # dataclasses can have many attributes
     # pylint: disable=too-many-instance-attributes
@@ -554,42 +566,35 @@ class Market(
 
     def apply_close_short_checkpointing(self, mint_time: float, bond_amount: float) -> None:
         """Close any outstanding shorts at the mint_time"""
-        # Get the total supply of shorts in the checkpoint of the shorts being closed. If the shorts
-        # are closed before maturity, we add the amount of shorts being closed since the total
-        # supply is decreased when burning the short tokens.
-        checkpoint_amount = self.market_state.total_supply_shorts[mint_time]
+        self._apply_close_checkpointing(mint_time, bond_amount, "short")
+
+    def apply_close_long_checkpointing(self, mint_time: float, bond_amount: float) -> None:
+        """Close any outstanding longs at the mint_time"""
+        self._apply_close_checkpointing(mint_time, bond_amount, "long")
+
+    def _apply_close_checkpointing(
+        self, mint_time: float, bond_amount: float, position: Literal["short", "long"]
+    ) -> None:
+        """Close any outstanding positions at the mint_time"""
+        # Get the total supply of positions in the checkpoint of the shorts being closed. If the
+        # positions are closed before maturity, we add the amount of the positions being closed
+        # since the total supply is decreased when burning the tokens.
+
+        total_supply = "total_supply_shorts" if position == "short" else "total_supply_longs"
+        base_volume = "short_base_volume" if position == "short" else "long_base_volume"
+
+        checkpoint_amount = self.market_state[total_supply][mint_time]
         maturity_time = mint_time + self.position_duration.days / 365
         if self.block_time.time < maturity_time:
             checkpoint_amount += bond_amount
         # If all of the shorts in the checkpoint are being closed, delete the base volume in the
         # checkpoint. Otherwise, decrease the base volume aggregates by a proportional amount.
         if bond_amount == checkpoint_amount:
-            self.market_state.short_base_volume -= self.market_state.checkpoints[mint_time].short_base_volume
-            self.market_state.checkpoints[mint_time].short_base_volume = 0
+            self.market_state[base_volume] -= self.market_state.checkpoints[mint_time][base_volume]
+            self.market_state.checkpoints[mint_time][base_volume] = 0
         else:
             proportional_base_volume = (
-                self.market_state.checkpoints[mint_time].short_base_volume * (bond_amount) / (checkpoint_amount)
+                self.market_state.checkpoints[mint_time][base_volume] * (bond_amount) / (checkpoint_amount)
             )
-            self.market_state.short_base_volume -= proportional_base_volume
-            self.market_state.checkpoints[mint_time].short_base_volume -= proportional_base_volume
-
-    def apply_close_long_checkpointing(self, mint_time: float, bond_amount: float) -> None:
-        """Close any outstanding longs at the mint_time"""
-        # Get the total supply of longs in the checkpoint of the longs being closed. If the longs
-        # are closed before maturity, we add the amount of longs being closed since the total supply
-        # is decreased when burning the long tokens.
-        maturity_time = mint_time + self.position_duration.days / 365
-        checkpoint_amount = self.market_state.total_supply_longs[mint_time]
-        if self.block_time.time < maturity_time:
-            checkpoint_amount += bond_amount
-        # If all of the longs in the checkpoint are being closed, delete the base volume in the
-        # checkpoint. Otherwise, decrease the base volume aggregates by a proportional amount.
-        if bond_amount == checkpoint_amount:
-            self.market_state.long_base_volume -= self.market_state.checkpoints[mint_time].long_base_volume
-            self.market_state.checkpoints[mint_time].long_base_volume = 0
-        else:
-            proportional_base_volume = self.market_state.checkpoints[mint_time].long_base_volume * (
-                bond_amount / checkpoint_amount
-            )
-            self.market_state.long_base_volume -= proportional_base_volume
-            self.market_state.checkpoints[mint_time].long_base_volume -= proportional_base_volume
+            self.market_state[base_volume] -= proportional_base_volume
+            self.market_state.checkpoints[mint_time][base_volume] -= proportional_base_volume

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -420,7 +420,7 @@ class Market(
         self.market_state.apply_delta(market_deltas)
         agent_wallet.update(agent_deltas)
         # apply checkpointing
-        self.apply_close_short_checkpointing(mint_time, bond_amount)
+        self.apply_close_checkpointing(mint_time, bond_amount, "short")
         return market_deltas, agent_deltas
 
     def open_long(
@@ -461,7 +461,7 @@ class Market(
         self.market_state.apply_delta(market_deltas)
         agent_wallet.update(agent_deltas)
         # apply checkpointing
-        self.apply_close_long_checkpointing(mint_time, bond_amount)
+        self.apply_close_checkpointing(mint_time, bond_amount, "long")
         return market_deltas, agent_deltas
 
     def add_liquidity(

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -19,6 +19,9 @@ import elfpy.time as time
 import elfpy.types as types
 import elfpy.utils.price as price_utils
 
+# dataclasses can have many attributes
+# pylint: disable=too-many-instance-attributes
+
 
 @dataclass
 class Checkpoint:
@@ -76,9 +79,6 @@ class MarketState(base_market.BaseMarketState):
 
     def __setitem__(self, key, value):
         return setattr(self, key, value)
-
-    # dataclasses can have many attributes
-    # pylint: disable=too-many-instance-attributes
 
     # lp reserves
     lp_total_supply: float = field(default=0.0)

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -551,7 +551,7 @@ class Market(
                 wallet.Wallet(0), matured_longs_amount, self, mint_time
             )
             self.market_state.apply_delta(market_deltas)
-            self.apply_close_long_checkpointing(mint_time, matured_longs_amount)
+            self.apply_close_checkpointing(mint_time, matured_longs_amount, "long")
 
         # TODO: pay out the short withdrawal pool for shorts that have matured.
         matured_shorts_amount = self.market_state.total_supply_shorts[mint_time]
@@ -561,18 +561,10 @@ class Market(
                 wallet.Wallet(0), matured_shorts_amount, self, mint_time, open_share_price
             )
             self.market_state.apply_delta(market_deltas)
-            self.apply_close_short_checkpointing(mint_time, matured_shorts_amount)
+            self.apply_close_checkpointing(mint_time, matured_longs_amount, "short")
         return self.market_state.checkpoints[checkpoint_time].share_price
 
-    def apply_close_short_checkpointing(self, mint_time: float, bond_amount: float) -> None:
-        """Close any outstanding shorts at the mint_time"""
-        self._apply_close_checkpointing(mint_time, bond_amount, "short")
-
-    def apply_close_long_checkpointing(self, mint_time: float, bond_amount: float) -> None:
-        """Close any outstanding longs at the mint_time"""
-        self._apply_close_checkpointing(mint_time, bond_amount, "long")
-
-    def _apply_close_checkpointing(
+    def apply_close_checkpointing(
         self, mint_time: float, bond_amount: float, position: Literal["short", "long"]
     ) -> None:
         """Close any outstanding positions at the mint_time"""

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -548,7 +548,7 @@ class Market(
         matured_longs_amount = self.market_state.total_supply_longs[mint_time]
         if matured_longs_amount > 0:
             market_deltas, _ = hyperdrive_actions.calc_close_long(
-                wallet.Wallet(0), matured_longs_amount, self, mint_time
+                wallet.Wallet(0).address, matured_longs_amount, self, mint_time
             )
             self.market_state.apply_delta(market_deltas)
             self.apply_close_checkpointing(mint_time, matured_longs_amount, "long")
@@ -558,7 +558,7 @@ class Market(
         if matured_shorts_amount > 0:
             open_share_price = self.market_state.checkpoints[mint_time].share_price
             market_deltas, _ = hyperdrive_actions.calc_close_short(
-                wallet.Wallet(0), matured_shorts_amount, self, mint_time, open_share_price
+                wallet.Wallet(0).address, matured_shorts_amount, self, mint_time, open_share_price
             )
             self.market_state.apply_delta(market_deltas)
             self.apply_close_checkpointing(mint_time, matured_longs_amount, "short")


### PR DESCRIPTION
Cleaning up the checkpointing logic a bit here, refactoring into methods so that open/close long/short methods in the hyperdrive market can stay clean.  I also experimented with pulling all the checkpointing code into it's own file but I think that's a little overkill for now.  going to land this and revisit.