### PR TITLE
use Decimal throughout codebase

### DIFF
--- a/elfpy/agents/agent.py
+++ b/elfpy/agents/agent.py
@@ -83,7 +83,7 @@ class Agent:
     # TODO: this function should optionally accept a target apr.  the short should not slip the
     # market fixed rate below the APR when opening the long
     # issue #213
-    def get_max_long(self, market: hyperdrive_market.Market) -> float:
+    def get_max_long(self, market: hyperdrive_market.Market) -> Decimal:
         """Gets an approximation of the maximum amount of base the agent can use
 
         Typically would be called to determine how much to enter into a long position.
@@ -95,10 +95,10 @@ class Agent:
 
         Returns
         -------
-        float
+        Decimal
             Maximum amount the agent can use to open a long
         """
-        (max_long, _) = market.pricing_model.get_max_long(
+        max_long, _ = market.pricing_model.get_max_long(
             market_state=market.market_state,
             time_remaining=market.position_duration,
         )

--- a/elfpy/agents/agent.py
+++ b/elfpy/agents/agent.py
@@ -110,7 +110,7 @@ class Agent:
     # TODO: this function should optionally accept a target apr.  the short should not slip the
     # market fixed rate above the APR when opening the short
     # issue #213
-    def get_max_short(self, market: hyperdrive_market.Market) -> float:
+    def get_max_short(self, market: hyperdrive_market.Market) -> Decimal:
         """Gets an approximation of the maximum amount of bonds the agent can short.
 
         Parameters
@@ -120,7 +120,7 @@ class Agent:
 
         Returns
         -------
-        float
+        Decimal
             Amount of base that the agent can short in the current market
         """
         # Get the market level max short.
@@ -163,7 +163,7 @@ class Agent:
             time_remaining=market.position_duration,
         )
         max_loss = last_maybe_max_short - trade_result.user_result.d_base
-        last_step_size = 1 / (2**num_iters + 1)
+        last_step_size = Decimal(1 / (2**num_iters + 1))
         if max_loss > self.wallet.balance.amount:
             bond_percent -= last_step_size
             last_maybe_max_short = max_short * bond_percent

--- a/elfpy/agents/agent.py
+++ b/elfpy/agents/agent.py
@@ -1,5 +1,6 @@
 """Implements abstract classes that control agent behavior"""
 from __future__ import annotations  # types will be strings by default in 3.11
+from decimal import Decimal
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -19,8 +20,8 @@ if TYPE_CHECKING:
 class AgentTradeResult:
     r"""The result to a user of performing a trade"""
 
-    d_base: float
-    d_bonds: float
+    d_base: Decimal
+    d_bonds: Decimal
 
 
 class Agent:

--- a/elfpy/agents/agent.py
+++ b/elfpy/agents/agent.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 import logging
+import numpy as np
 
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.agents.wallet as wallet
@@ -48,9 +49,9 @@ class Agent:
         Wallet object which tracks the agent's asset balances
     """
 
-    def __init__(self, wallet_address: int, budget: float):
+    def __init__(self, wallet_address: int, budget: Decimal):
         """Set up initial conditions"""
-        self.budget: float = budget
+        self.budget: Decimal = budget
         self.wallet: wallet.Wallet = wallet.Wallet(
             address=wallet_address, balance=types.Quantity(amount=budget, unit=types.TokenType.BASE)
         )
@@ -101,7 +102,7 @@ class Agent:
             market_state=market.market_state,
             time_remaining=market.position_duration,
         )
-        return min(
+        return np.min(
             self.wallet.balance.amount,
             max_long,
         )
@@ -131,8 +132,8 @@ class Agent:
         # short, we can simply return the maximum short.
         if self.wallet.balance.amount >= max_short_max_loss:
             return max_short
-        last_maybe_max_short = 0
-        bond_percent = 1
+        last_maybe_max_short = Decimal(0)
+        bond_percent = Decimal(1)
         num_iters = 25
         for step_size in [1 / (2 ** (x + 1)) for x in range(num_iters)]:
             # Compute the amount of base returned by selling the specified

--- a/elfpy/agents/policies/lp_and_withdraw.py
+++ b/elfpy/agents/policies/lp_and_withdraw.py
@@ -3,6 +3,7 @@ import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 import elfpy.agents.agent as agent
 import elfpy.types as types
+from decimal import Decimal
 
 # pylint: disable=duplicate-code
 
@@ -13,10 +14,10 @@ class Policy(agent.Agent):
     only has one LP open at a time
     """
 
-    def __init__(self, wallet_address, budget=1000):
+    def __init__(self, wallet_address: int, budget: Decimal = Decimal(1000)):
         """call basic policy init then add custom stuff"""
-        self.time_to_withdraw = 1.0
-        self.amount_to_lp = 100
+        self.time_to_withdraw = Decimal(1)
+        self.amount_to_lp = Decimal(100)
         super().__init__(wallet_address, budget)
 
     def action(self, market: hyperdrive_market.Market) -> "list[types.Trade]":

--- a/elfpy/agents/policies/single_lp.py
+++ b/elfpy/agents/policies/single_lp.py
@@ -3,6 +3,7 @@ import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 import elfpy.agents.agent as agent
 import elfpy.types as types
+from decimal import Decimal
 
 # TODO: the init calls are replicated across each strategy, which looks like duplicate code
 #     this should be resolved once we fix user inheritance
@@ -13,9 +14,9 @@ import elfpy.types as types
 class Policy(agent.Agent):
     """simple LP that only has one LP open at a time"""
 
-    def __init__(self, wallet_address, budget=1000):
+    def __init__(self, wallet_address: int, budget: Decimal = Decimal(1000)):
         """call basic policy init then add custom stuff"""
-        self.amount_to_lp = 100
+        self.amount_to_lp = Decimal(100)
         super().__init__(wallet_address, budget)
 
     def action(self, _market: hyperdrive_market.Market) -> "list[types.Trade]":

--- a/elfpy/agents/policies/single_short.py
+++ b/elfpy/agents/policies/single_short.py
@@ -3,6 +3,7 @@ import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 import elfpy.agents.agent as agent
 import elfpy.types as types
+from decimal import Decimal
 
 # pylint: disable=duplicate-code
 
@@ -10,7 +11,7 @@ import elfpy.types as types
 class Policy(agent.Agent):
     """simple short thatonly has one long open at a time"""
 
-    def __init__(self, wallet_address, budget=100):
+    def __init__(self, wallet_address, budget: Decimal = Decimal(100)):
         """call basic policy init then add custom stuff"""
         self.amount_to_trade = budget
         super().__init__(wallet_address, budget)

--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -188,7 +188,7 @@ class Wallet:
                 # of open borrows using `if self.borrows`
                 del self.borrows[borrow_summary.start_time]
 
-    def _update_longs(self, longs: Iterable[tuple[float, Long]]) -> None:
+    def _update_longs(self, longs: Iterable[tuple[Decimal, Long]]) -> None:
         """Helper internal function that updates the data about Longs contained in the Agent's Wallet object
 
         Parameters
@@ -217,7 +217,7 @@ class Wallet:
             if mint_time in self.longs and self.longs[mint_time].balance < 0:
                 raise AssertionError(f"ERROR: Wallet balance should be >= 0, not {self.longs[mint_time]}.")
 
-    def _update_shorts(self, shorts: Iterable[tuple[float, Short]]) -> None:
+    def _update_shorts(self, shorts: Iterable[tuple[Decimal, Short]]) -> None:
         """Helper internal function that updates the data about Shortscontained in the Agent's Wallet object
 
         Parameters
@@ -257,7 +257,7 @@ class Wallet:
             if mint_time in self.shorts and self.shorts[mint_time].balance < 0:
                 raise AssertionError(f"ERROR: Wallet balance should be >= 0, not {self.shorts[mint_time]}.")
 
-    def get_state(self, market: hyperdrive_market.Market) -> dict[str, float]:
+    def get_state(self, market: hyperdrive_market.Market) -> dict[str, Decimal | int]:
         r"""The wallet's current state of public variables
 
         .. todo:: This will go away once we finish refactoring the state
@@ -273,8 +273,8 @@ class Wallet:
             lp_token_value = pool_value * share_of_pool  # in base
         share_reserves = market.market_state.share_reserves
         # compute long values in units of base
-        longs_value = 0
-        longs_value_no_mock = 0
+        longs_value = Decimal(0)
+        longs_value_no_mock = Decimal(0)
         for mint_time, long in self.longs.items():
             if long.balance > 0 and share_reserves:
                 balance = hyperdrive_actions.calc_close_long(
@@ -284,14 +284,14 @@ class Wallet:
                     mint_time=mint_time,
                 )[1].balance.amount
             else:
-                balance = 0.0
+                balance = Decimal(0)
             longs_value += balance
             longs_value_no_mock += long.balance * market.spot_price
         # compute short values in units of base
         shorts_value = 0
         shorts_value_no_mock = 0
         for mint_time, short in self.shorts.items():
-            balance = 0.0
+            balance = Decimal(0)
             if (
                 short.balance > 0
                 and share_reserves > 0

--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -54,21 +54,21 @@ class Borrow:
     ----------
     borrow_token : TokenType
     .. todo: add explanation
-    borrow_amount : float
+    borrow_amount : Decimal
     .. todo: add explanation
     collateral_token : TokenType
     .. todo: add explanation
-    collateral_amount: float
+    collateral_amount: Decimal
     .. todo: add explanation
-    start_time : float
+    start_time : Decimal
     .. todo: add explanation
     """
     borrow_token: types.TokenType
-    borrow_amount: float
-    borrow_shares: float
+    borrow_amount: Decimal
+    borrow_shares: Decimal
     collateral_token: types.TokenType
-    collateral_amount: float
-    start_time: float
+    collateral_amount: Decimal
+    start_time: Decimal
 
 
 @dataclass()
@@ -100,10 +100,12 @@ class Wallet:
     address: int
 
     # fungible
-    balance: types.Quantity = field(default_factory=lambda: types.Quantity(amount=0, unit=types.TokenType.BASE))
+    balance: types.Quantity = field(
+        default_factory=lambda: types.Quantity(amount=Decimal(0), unit=types.TokenType.BASE)
+    )
     # TODO: Support multiple typed balances:
     #     balance: Dict[types.TokenType, types.Quantity] = field(default_factory=dict)
-    lp_tokens: Decimal = field(default_factory=Decimal)
+    lp_tokens: Decimal = field(default=Decimal(0))
 
     # non-fungible (identified by key=mint_time, stored as dict)
     longs: dict[Decimal, Long] = field(default_factory=dict)
@@ -111,7 +113,7 @@ class Wallet:
     # borrow and  collateral have token type, which is not represented here
     # this therefore assumes that only one token type can be used at any given mint time
     borrows: dict[Decimal, Borrow] = field(default_factory=dict)
-    fees_paid: Decimal = 0
+    fees_paid: Decimal = field(default=Decimal(0))
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)
@@ -171,7 +173,7 @@ class Wallet:
             else:
                 raise ValueError(f"wallet_key={key} is not allowed.")
 
-    def _update_borrows(self, borrows: Iterable[tuple[float, Borrow]]) -> None:
+    def _update_borrows(self, borrows: Iterable[tuple[Decimal, Borrow]]) -> None:
         for mint_time, borrow_summary in borrows:
             if mint_time != borrow_summary.start_time:
                 raise ValueError(

--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -83,13 +83,13 @@ class Wallet:
         The base assets that held by the agent.
     lp_tokens : float
         The LP tokens held by the agent.
-    longs : Dict[float, Long]
+    longs : Dict[Decimal, Long]
         The long positions held by the agent.
-    shorts : Dict[float, Short]
+    shorts : Dict[Decimal, Short]
         The short positions held by the agent.
-    borrows : Dict[float, Borrow]
+    borrows : Dict[Decimal, Borrow]
         The borrow positions held by the agent.
-    fees_paid : float
+    fees_paid : Decimal
         The fees paid by the agent.
     """
 
@@ -106,12 +106,12 @@ class Wallet:
     lp_tokens: Decimal = field(default_factory=Decimal)
 
     # non-fungible (identified by key=mint_time, stored as dict)
-    longs: dict[float, Long] = field(default_factory=dict)
-    shorts: dict[float, Short] = field(default_factory=dict)
+    longs: dict[Decimal, Long] = field(default_factory=dict)
+    shorts: dict[Decimal, Short] = field(default_factory=dict)
     # borrow and  collateral have token type, which is not represented here
     # this therefore assumes that only one token type can be used at any given mint time
-    borrows: dict[float, Borrow] = field(default_factory=dict)
-    fees_paid: float = 0
+    borrows: dict[Decimal, Borrow] = field(default_factory=dict)
+    fees_paid: Decimal = 0
 
     def __getitem__(self, key: str) -> Any:
         return getattr(self, key)

--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -77,17 +77,19 @@ class Wallet:
     Parameters
     ----------
     address : int
-        The trader's address.
+        The agent's address.
     balance : Quantity
-        The base assets that held by the trader.
+        The base assets that held by the agent.
     lp_tokens : float
-        The LP tokens held by the trader.
+        The LP tokens held by the agent.
     longs : Dict[float, Long]
-        The long positions held by the trader.
+        The long positions held by the agent.
     shorts : Dict[float, Short]
-        The short positions held by the trader.
+        The short positions held by the agent.
+    borrows : Dict[float, Borrow]
+        The borrow positions held by the agent.
     fees_paid : float
-        The fees paid by the wallet.
+        The fees paid by the agent.
     """
 
     # pylint: disable=too-many-instance-attributes

--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -5,6 +5,7 @@ import logging
 import copy
 from typing import TYPE_CHECKING
 from dataclasses import dataclass, field
+from decimal import Decimal
 
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.types as types
@@ -102,7 +103,7 @@ class Wallet:
     balance: types.Quantity = field(default_factory=lambda: types.Quantity(amount=0, unit=types.TokenType.BASE))
     # TODO: Support multiple typed balances:
     #     balance: Dict[types.TokenType, types.Quantity] = field(default_factory=dict)
-    lp_tokens: float = 0
+    lp_tokens: Decimal = field(default_factory=Decimal)
 
     # non-fungible (identified by key=mint_time, stored as dict)
     longs: dict[float, Long] = field(default_factory=dict)

--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -21,13 +21,13 @@ class Long:
 
     Parameters
     ----------
-    balance : float
+    balance : Decimal
         The amount of bonds that the position is long.
 
     .. todo:: make balance a Quantity to enforce units
     """
 
-    balance: float  # bonds
+    balance: Decimal  # bonds
 
 
 @dataclass
@@ -36,14 +36,14 @@ class Short:
 
     Parameters
     ----------
-    balance : float
+    balance : Decimal
         The amount of bonds that the position is short.
-    open_share_price: float
+    open_share_price: Decimal
         The share price at the time the short was opened.
     """
 
-    balance: float
-    open_share_price: float
+    balance: Decimal
+    open_share_price: Decimal
 
 
 @dataclass

--- a/elfpy/markets/base.py
+++ b/elfpy/markets/base.py
@@ -117,7 +117,7 @@ class Market(Generic[State, Deltas, PricingModel]):
         for key, value in market_deltas.__dict__.items():
             if value:  # check that it's instantiated and non-empty
                 value_to_check = value.amount if isinstance(value, types.Quantity) else value
-                assert np.isfinite(value_to_check), f"ERROR: market delta key {key} is not finite."
+                assert np.isfinite(float(value_to_check)), f"ERROR: market delta key {key} is not finite."
 
     def update_market(self, market_deltas: Deltas) -> None:
         """Increments member variables to reflect current market conditions"""

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -56,10 +56,10 @@ class MarketDeltas(base_market.MarketDeltas):
     short_withdrawal_shares_outstanding: float = 0
     long_withdrawal_share_proceeds: float = 0
     short_withdrawal_share_proceeds: float = 0
-    long_checkpoints: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
-    short_checkpoints: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
-    total_supply_longs: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
-    total_supply_shorts: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
+    long_checkpoints: defaultdict[Decimal, Decimal] = field(default_factory=lambda: defaultdict(Decimal))
+    short_checkpoints: defaultdict[Decimal, Decimal] = field(default_factory=lambda: defaultdict(Decimal))
+    total_supply_longs: defaultdict[Decimal, Decimal] = field(default_factory=lambda: defaultdict(Decimal))
+    total_supply_shorts: defaultdict[Decimal, Decimal] = field(default_factory=lambda: defaultdict(Decimal))
 
 
 @types.freezable(frozen=True, no_new_attribs=True)
@@ -182,7 +182,7 @@ def calc_close_short(
     wallet_address: int,
     bond_amount: float,
     market: hyperdrive_market.Market,
-    mint_time: float,
+    mint_time: Decimal,
     open_share_price: float,
 ) -> tuple[MarketDeltas, wallet.Wallet]:
     """
@@ -341,7 +341,7 @@ def calc_close_long(
     wallet_address: int,
     bond_amount: float,
     market: hyperdrive_market.Market,
-    mint_time: float,
+    mint_time: Decimal,
 ) -> tuple[MarketDeltas, wallet.Wallet]:
     """Calculations for closing a long position.
     This function takes the trade spec & turn it into trade details.

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -554,7 +554,7 @@ def update_weighted_average(  # pylint: disable=too-many-arguments
     total_weight: Decimal,
     delta: Decimal,
     delta_weight: Decimal,
-    is_adding: Decimal,
+    is_adding: bool,
 ) -> Decimal:
     """Updates a weighted average by adding or removing a weighted delta."""
     if is_adding:

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -111,7 +111,7 @@ def check_action(agent_action: MarketAction) -> None:
 
 def calc_open_short(
     wallet_address: int,
-    bond_amount: float,
+    bond_amount: Decimal,
     market: hyperdrive_market.Market,
 ) -> tuple[MarketDeltas, wallet.Wallet]:
     """Calculate the agent & market deltas for opening a short position.
@@ -550,17 +550,17 @@ def calculate_base_volume(base_amount: Decimal, bond_amount: Decimal, normalized
 
 
 def update_weighted_average(  # pylint: disable=too-many-arguments
-    average: float,
-    total_weight: float,
-    delta: float,
-    delta_weight: float,
-    is_adding: float,
-) -> float:
+    average: Decimal,
+    total_weight: Decimal,
+    delta: Decimal,
+    delta_weight: Decimal,
+    is_adding: Decimal,
+) -> Decimal:
     """Updates a weighted average by adding or removing a weighted delta."""
     if is_adding:
         return (total_weight * average + delta_weight * delta) / (total_weight + delta_weight)
     if total_weight == delta_weight:
-        return 0
+        return Decimal(0)
     return (total_weight * average - delta_weight * delta) / (total_weight - delta_weight)
 
 

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -391,7 +391,7 @@ def calc_close_long(
         longs_outstanding=-bond_amount,
         long_average_maturity_time=d_long_average_maturity_time,
         long_checkpoints=d_checkpoints,
-        total_supply_longs=defaultdict(float, {mint_time: -bond_amount}),
+        total_supply_longs=defaultdict(Decimal, {mint_time: -bond_amount}),
     )
     agent_deltas = wallet.Wallet(
         address=wallet_address,

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -153,7 +153,9 @@ def calc_open_short(
         else d_short_average_maturity_time
     )
     # calculate_base_volume needs a positive base, so we use the value from user_result
-    base_volume = calculate_base_volume(trade_result.user_result.d_base, bond_amount, 1)
+    base_volume = calculate_base_volume(
+        base_amount=trade_result.user_result.d_base, bond_amount=bond_amount, normalized_time_remaining=Decimal(1)
+    )
     # return the market and wallet deltas
     market_deltas = MarketDeltas(
         d_base_asset=trade_result.market_result.d_base,
@@ -315,7 +317,11 @@ def calc_open_long(
     )
     d_long_average_maturity_time = long_average_maturity_time - market.market_state.long_average_maturity_time
     # TODO: don't use 1 for time_remaining once we have checkpointing
-    base_volume = calculate_base_volume(trade_result.market_result.d_base, base_amount, 1)
+    base_volume = calculate_base_volume(
+        base_amount=trade_result.market_result.d_base,
+        bond_amount=base_amount,
+        normalized_time_remaining=Decimal(1),
+    )
     # TODO: add accounting for withdrawal shares
     # Get the market and wallet deltas to return.
     market_deltas = MarketDeltas(
@@ -325,8 +331,8 @@ def calc_open_long(
         long_base_volume=base_volume,
         longs_outstanding=trade_result.user_result.d_bonds,
         long_average_maturity_time=d_long_average_maturity_time,
-        long_checkpoints=defaultdict(float, {market.latest_checkpoint_time: base_volume}),
-        total_supply_longs=defaultdict(float, {market.latest_checkpoint_time: trade_result.user_result.d_bonds}),
+        long_checkpoints=defaultdict(Decimal, {market.latest_checkpoint_time: base_volume}),
+        total_supply_longs=defaultdict(Decimal, {market.latest_checkpoint_time: trade_result.user_result.d_bonds}),
     )
     agent_deltas = wallet.Wallet(
         address=wallet_address,

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -446,7 +446,7 @@ def calc_add_liquidity(
 
 def calc_remove_liquidity(
     wallet_address: int,
-    bond_amount: float,
+    bond_amount: Decimal,
     market: hyperdrive_market.Market,
 ) -> tuple[MarketDeltas, wallet.Wallet]:
     """Computes new deltas for bond & share reserves after liquidity is removed"""

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -485,7 +485,7 @@ def calculate_short_adjustment(
 ) -> Decimal:
     """Calculates an adjustment amount for lp shares"""
     if market_time > market_state.short_average_maturity_time:
-        return 0
+        return Decimal(0)
     # (year_end - year_start) / (normalizing_constant / 365)
     normalized_time_remaining = (market_state.short_average_maturity_time - market_time) / (
         position_duration.normalizing_constant / 365

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -531,7 +531,7 @@ def calculate_lp_allocation_adjustment(
     return base_adjustment / share_price
 
 
-def calculate_base_volume(base_amount: float, bond_amount: float, normalized_time_remaining: float) -> float:
+def calculate_base_volume(base_amount: Decimal, bond_amount: Decimal, normalized_time_remaining: Decimal) -> Decimal:
     """Calculates the base volume of an open trade.
     Output is given the base amount, the bond amount, and the time remaining.
     Since the base amount takes into account backdating, we can't use this as our base volume.
@@ -545,7 +545,7 @@ def calculate_base_volume(base_amount: float, bond_amount: float, normalized_tim
     # If the time remaining is 0, the position has already matured and doesn't have an impact on
     # LP's ability to withdraw. This is a pathological case that should never arise.
     if normalized_time_remaining == 0:
-        return 0
+        return Decimal(0)
     return (base_amount - (1 - normalized_time_remaining) * bond_amount) / normalized_time_remaining
 
 

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -43,7 +43,7 @@ class MarketDeltas(base_market.MarketDeltas):
     d_base_asset: Decimal = field(default=Decimal(0))
     d_bond_asset: Decimal = field(default=Decimal(0))
     d_base_buffer: Decimal = field(default=Decimal(0))
-    d_bond_buffer: float = 0
+    d_bond_buffer: Decimal = field(default=Decimal(0))
     d_lp_total_supply: Decimal = field(default=Decimal(0))
     d_share_price: Decimal = field(default=Decimal(0))
     longs_outstanding: Decimal = field(default=Decimal(0))
@@ -162,8 +162,8 @@ def calc_open_short(
         short_base_volume=base_volume,
         shorts_outstanding=bond_amount,
         short_average_maturity_time=d_short_average_maturity_time,
-        short_checkpoints=defaultdict(float, {market.latest_checkpoint_time: base_volume}),
-        total_supply_shorts=defaultdict(float, {market.latest_checkpoint_time: bond_amount}),
+        short_checkpoints=defaultdict(Decimal, {market.latest_checkpoint_time: base_volume}),
+        total_supply_shorts=defaultdict(Decimal, {market.latest_checkpoint_time: bond_amount}),
     )
     # amount to cover the worst case scenario where p=1. this amount is 1-p. see logic above.
     max_loss = bond_amount - trade_result.user_result.d_base
@@ -240,7 +240,7 @@ def calc_close_short(
         shorts_outstanding=-bond_amount,
         short_average_maturity_time=d_short_average_maturity_time,
         short_checkpoints=d_checkpoints,
-        total_supply_shorts=defaultdict(float, {mint_time: -bond_amount}),
+        total_supply_shorts=defaultdict(Decimal, {mint_time: -bond_amount}),
     )
     agent_deltas = wallet.Wallet(
         address=wallet_address,
@@ -251,7 +251,7 @@ def calc_close_short(
         shorts={
             mint_time: wallet.Short(
                 balance=-bond_amount,
-                open_share_price=0,
+                open_share_price=Decimal(0),
             )
         },
         fees_paid=trade_result.breakdown.fee,
@@ -626,7 +626,7 @@ def calc_checkpoint_deltas(
     checkpoint_amount = market.market_state[total_supply][checkpoint_time]
     # If the checkpoint has nothing stored, then do not update
     if checkpoint_amount == 0:
-        return (0, defaultdict(Decimal, {checkpoint_time: Decimal(0)}))
+        return (Decimal(0), defaultdict(Decimal, {checkpoint_time: Decimal(0)}))
     # If all of the positions in the checkpoint are being closed, delete the base volume in the
     # checkpoint and reduce the aggregates by the checkpoint amount. Otherwise, decrease the
     # both the checkpoints and aggregates by a proportional amount.

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -481,8 +481,8 @@ def calc_remove_liquidity(
 def calculate_short_adjustment(
     market_state: hyperdrive_market.MarketState,
     position_duration: time.StretchedTime,
-    market_time: float,
-) -> float:
+    market_time: Decimal,
+) -> Decimal:
     """Calculates an adjustment amount for lp shares"""
     if market_time > market_state.short_average_maturity_time:
         return 0

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -180,10 +180,10 @@ def calc_open_short(
 
 def calc_close_short(
     wallet_address: int,
-    bond_amount: float,
+    bond_amount: Decimal,
     market: hyperdrive_market.Market,
     mint_time: Decimal,
-    open_share_price: float,
+    open_share_price: Decimal,
 ) -> tuple[MarketDeltas, wallet.Wallet]:
     """
     when closing a short, the number of bonds being closed out, at face value, give us the total margin returned

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -519,11 +519,11 @@ def calculate_long_adjustment(
 
 
 def calculate_lp_allocation_adjustment(
-    positions_outstanding: float,
-    base_volume: float,
-    average_time_remaining: float,
-    share_price: float,
-) -> float:
+    positions_outstanding: Decimal,
+    base_volume: Decimal,
+    average_time_remaining: Decimal,
+    share_price: Decimal,
+) -> Decimal:
     """Calculates an adjustment amount for lp shares"""
     # base_adjustment = t * base_volume + (1 - t) * _positions_outstanding
     base_adjustment = (average_time_remaining * base_volume) + (1 - average_time_remaining) * positions_outstanding

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -501,8 +501,8 @@ def calculate_short_adjustment(
 def calculate_long_adjustment(
     market_state: hyperdrive_market.MarketState,
     position_duration: time.StretchedTime,
-    market_time: float,
-) -> float:
+    market_time: Decimal,
+) -> Decimal:
     """Calculates an adjustment amount for lp shares"""
     if market_time > market_state.long_average_maturity_time:
         return 0

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -565,12 +565,12 @@ def update_weighted_average(  # pylint: disable=too-many-arguments
 
 
 def calc_lp_out_given_tokens_in(
-    d_base: float,
-    rate: float,
+    d_base: Decimal,
+    rate: Decimal,
     market_state: hyperdrive_market.MarketState,
-    market_time: float,
+    market_time: Decimal,
     position_duration: time.StretchedTime,
-) -> tuple[float, float, float]:
+) -> tuple[Decimal, Decimal, Decimal]:
     r"""Computes the amount of LP tokens to be minted for a given amount of base asset
 
     .. math::

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -40,18 +40,18 @@ class MarketActionType(Enum):
 class MarketDeltas(base_market.MarketDeltas):
     r"""Specifies changes to values in the market"""
     # pylint: disable=too-many-instance-attributes
-    d_base_asset: Decimal = field(default_factory=Decimal)
-    d_bond_asset: Decimal = field(default_factory=Decimal)
-    d_base_buffer: Decimal = field(default_factory=Decimal)
+    d_base_asset: Decimal = field(default=Decimal(0))
+    d_bond_asset: Decimal = field(default=Decimal(0))
+    d_base_buffer: Decimal = field(default=Decimal(0))
     d_bond_buffer: float = 0
-    d_lp_total_supply: Decimal = field(default_factory=Decimal)
-    d_share_price: Decimal = field(default_factory=Decimal)
-    longs_outstanding: Decimal = field(default_factory=Decimal)
-    shorts_outstanding: Decimal = field(default_factory=Decimal)
-    long_average_maturity_time: Decimal = field(default_factory=Decimal)
-    short_average_maturity_time: Decimal = field(default_factory=Decimal)
-    long_base_volume: Decimal = field(default_factory=Decimal)
-    short_base_volume: Decimal = field(default_factory=Decimal)
+    d_lp_total_supply: Decimal = field(default=Decimal(0))
+    d_share_price: Decimal = field(default=Decimal(0))
+    longs_outstanding: Decimal = field(default=Decimal(0))
+    shorts_outstanding: Decimal = field(default=Decimal(0))
+    long_average_maturity_time: Decimal = field(default=Decimal(0))
+    short_average_maturity_time: Decimal = field(default=Decimal(0))
+    long_base_volume: Decimal = field(default=Decimal(0))
+    short_base_volume: Decimal = field(default=Decimal(0))
     long_withdrawal_shares_outstanding: float = 0
     short_withdrawal_shares_outstanding: float = 0
     long_withdrawal_share_proceeds: float = 0
@@ -77,13 +77,13 @@ class MarketAction(base_market.MarketAction):
     # these two variables are required to be set by the strategy
     action_type: MarketActionType
     # amount to supply for the action
-    trade_amount: float  # TODO: should this be a Quantity, not a float? Make sure, then delete fixme
+    trade_amount: Decimal  # TODO: should this be a Quantity, not a float? Make sure, then delete fixme
     # the agent's wallet
     wallet: wallet.Wallet
     # min amount to receive for the action
-    min_amount_out: float = 0
+    min_amount_out: Decimal = Decimal(0)
     # mint time is set only for trades that act on existing positions (close long or close short)
-    mint_time: Optional[float] = None
+    mint_time: Optional[Decimal] = None
 
 
 def check_action(agent_action: MarketAction) -> None:

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -40,18 +40,18 @@ class MarketActionType(Enum):
 class MarketDeltas(base_market.MarketDeltas):
     r"""Specifies changes to values in the market"""
     # pylint: disable=too-many-instance-attributes
-    d_base_asset: float = 0
-    d_bond_asset: float = 0
-    d_base_buffer: float = 0
+    d_base_asset: Decimal = field(default_factory=Decimal)
+    d_bond_asset: Decimal = field(default_factory=Decimal)
+    d_base_buffer: Decimal = field(default_factory=Decimal)
     d_bond_buffer: float = 0
-    d_lp_total_supply: float = 0
-    d_share_price: float = 0
-    longs_outstanding: float = 0
-    shorts_outstanding: float = 0
-    long_average_maturity_time: float = 0
-    short_average_maturity_time: float = 0
-    long_base_volume: float = 0
-    short_base_volume: float = 0
+    d_lp_total_supply: Decimal = field(default_factory=Decimal)
+    d_share_price: Decimal = field(default_factory=Decimal)
+    longs_outstanding: Decimal = field(default_factory=Decimal)
+    shorts_outstanding: Decimal = field(default_factory=Decimal)
+    long_average_maturity_time: Decimal = field(default_factory=Decimal)
+    short_average_maturity_time: Decimal = field(default_factory=Decimal)
+    long_base_volume: Decimal = field(default_factory=Decimal)
+    short_base_volume: Decimal = field(default_factory=Decimal)
     long_withdrawal_shares_outstanding: float = 0
     short_withdrawal_shares_outstanding: float = 0
     long_withdrawal_share_proceeds: float = 0

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -412,7 +412,7 @@ def calc_add_liquidity(
     if (
         market.market_state.share_reserves == 0 and market.market_state.bond_reserves == 0
     ):  # pool has not been initialized
-        rate = 0
+        rate = Decimal(0)
     else:
         rate = market.fixed_apr
     # sanity check inputs

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -1,5 +1,6 @@
 """Market simulators store state information when interfacing AMM pricing models with users."""
 from __future__ import annotations  # types will be strings by default in 3.11
+from decimal import Decimal
 
 from dataclasses import dataclass, field
 from collections import defaultdict
@@ -65,8 +66,8 @@ class MarketDeltas(base_market.MarketDeltas):
 @dataclass
 class MarketActionResult(base_market.MarketActionResult):
     r"""The result to a market of performing a trade"""
-    d_base: float
-    d_bonds: float
+    d_base: Decimal
+    d_bonds: Decimal
 
 
 @types.freezable(frozen=False, no_new_attribs=True)

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -120,10 +120,10 @@ class MarketState(base_market.BaseMarketState):
 
     # trading buffers
     base_buffer: Decimal = field(default=Decimal(0))
-    bond_buffer: float = field(default=0.0)
+    bond_buffer: Decimal = field(default=Decimal(0))
 
     # share price
-    variable_apr: float = field(default=0.0)
+    variable_apr: Decimal = field(default=Decimal(0))
     share_price: Decimal = field(default=Decimal(0))
     init_share_price: Decimal = field(default=Decimal(0))
 
@@ -443,8 +443,8 @@ class Market(
     def close_short(
         self,
         agent_wallet: wallet.Wallet,
-        open_share_price: float,
-        bond_amount: float,
+        open_share_price: Decimals,
+        bond_amount: Decimal,
         mint_time: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Calculate the deltas from closing a short and then update the agent wallet & market state"""

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -231,7 +231,7 @@ class Market(
         super().__init__(pricing_model=pricing_model, market_state=market_state, block_time=block_time)
 
     @property
-    def annualized_position_duration(self) -> float:
+    def annualized_position_duration(self) -> Decimal:
         r"""Returns the position duration in years"""
         return self.position_duration.days / 365
 

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -73,6 +73,36 @@ class MarketState(base_market.BaseMarketState):
         as a fee.
     redemption_fee_percent : float
         A flat fee applied to the output.  Not used in this equation for Yieldspace.
+    longs_outstanding: Decimal
+        Amount of bonds that agents have long positions on, in units of bonds
+    shorts_outstanding: Decimal
+        Amount of bonds that agents have long positions on, in units of bonds
+    long_average_maturity_time: Decimal
+        Average maturity time of long positions
+    short_average_maturity_time: Decimal
+        Average maturity time of short positions
+    long_base_volume: Decimal
+        Amount of base that agents have paid to open long positions, in units of base
+    short_base_volume: Decimal
+        Amount of base that agents have paid to open short positions, in units of base
+    checkpoints: defaultdict[float, Checkpoint]
+        Checkpoints are used to avoid poking in periods that have LP or trading activity.
+        The checkpoints contain the starting share price from the checkpoint as well as
+        aggregate volume values.
+    checkpoint_duration: float
+        Time between checkpoints, defaults to 1 day
+    total_supply_longs: defaultdict[float, float]
+        Checkpointed total supply for longs stored as {checkpoint_time: bond_amount}
+    total_supply_shorts: defaultdict[float, float]
+        Checkpointed total supply for shorts stored as {checkpoint_time: bond_amount}
+    long_withdrawal_shares_outstanding: float
+        The amount of long withdrawal shares that are still open.
+    short_withdrawal_shares_outstanding: float
+        The amount of short withdrawal shares that are still open.
+    long_withdrawal_share_proceeds: float
+        The amount that has accrued to long withdrawal shares.
+    short_withdrawal_share_proceeds: float
+        The amount that has accrued to short withdrawal shares.
     """
 
     def __getitem__(self, key):

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -146,11 +146,11 @@ class MarketState(base_market.BaseMarketState):
     # time delimited checkpoints
     checkpoints: defaultdict[Decimal, Checkpoint] = field(default_factory=lambda: defaultdict(Checkpoint))
     # time between checkpoints, defaults to 1 day
-    checkpoint_duration: float = field(default=1 / 365)
+    checkpoint_duration: Decimal = field(default=Decimal(1 / 365))
     # checkpointed total supply for longs stored as {checkpoint_time: bond_amount}
-    total_supply_longs: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
+    total_supply_longs: defaultdict[Decimal, Decimal] = field(default_factory=lambda: defaultdict(Decimal))
     # checkpointed total supply for shorts stored as {checkpoint_time: bond_amount}
-    total_supply_shorts: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
+    total_supply_shorts: defaultdict[Decimal, Decimal] = field(default_factory=lambda: defaultdict(Decimal))
 
     # the amount of long withdrawal shares that haven't been paid out.
     long_withdrawal_shares_outstanding: float = field(default=0.0)
@@ -445,7 +445,7 @@ class Market(
         agent_wallet: wallet.Wallet,
         open_share_price: float,
         bond_amount: float,
-        mint_time: float,
+        mint_time: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Calculate the deltas from closing a short and then update the agent wallet & market state"""
         # create/update the checkpoint
@@ -486,7 +486,7 @@ class Market(
         self,
         agent_wallet: wallet.Wallet,
         bond_amount: float,
-        mint_time: float,
+        mint_time: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Calculate the deltas from closing a long and then update the agent wallet & market state"""
         # create/update the checkpoint
@@ -535,7 +535,7 @@ class Market(
         agent_wallet.update(agent_deltas)
         return market_deltas, agent_deltas
 
-    def checkpoint(self, checkpoint_time: float) -> None:
+    def checkpoint(self, checkpoint_time: Decimal) -> None:
         """allows anyone to mint a new checkpoint."""
         # if the checkpoint has already been set, return early.
         if self.market_state.checkpoints[checkpoint_time].share_price != 0:
@@ -578,14 +578,14 @@ class Market(
 
         Parameters
         ----------
-        checkpoint_time: float
+        checkpoint_time: Decimal
             The block time for the checkpoint to be created or cleared.
-        share_price: float
+        share_price: Decimal
             The share price of the market at the checkpoint time.
 
         Returns
         -------
-        float
+        Decimal
             The share price for the checkpoint after mature positions have been closed.
         """
         # Return early if the checkpoint has already been updated.

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -50,7 +50,7 @@ class MarketState(base_market.BaseMarketState):
 
     Attributes
     ----------
-    lp_total_supply: float
+    lp_total_supply: Decimal
         Amount of lp tokens
     share_reserves: Decimal
         Quantity of shares stored in the market
@@ -82,7 +82,7 @@ class MarketState(base_market.BaseMarketState):
         return setattr(self, key, value)
 
     # lp reserves
-    lp_total_supply: float = field(default=0.0)
+    lp_total_supply: Decimal = field(default=Decimal(0))
 
     # trading reserves
     share_reserves: Decimal = field(default=Decimal(0))

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -248,11 +248,11 @@ class Market(
         return price_utils.calc_apr_from_spot_price(price=self.spot_price, time_remaining=self.position_duration)
 
     @property
-    def spot_price(self) -> float:
+    def spot_price(self) -> Decimal:
         """Returns the current market price of the share reserves"""
         # calc_spot_price_from_reserves will throw an error if share_reserves is zero
         if self.market_state.share_reserves == 0:  # market is empty
-            return np.nan
+            return Decimal(np.nan)
         return self.pricing_model.calc_spot_price_from_reserves(
             market_state=self.market_state,
             time_remaining=self.position_duration,

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -106,9 +106,9 @@ class MarketState(base_market.BaseMarketState):
     # the amount of shorts that are still open.
     shorts_outstanding: float = field(default=0.0)
     # the average maturity time of long positions.
-    long_average_maturity_time: float = field(default=0.0)
+    long_average_maturity_time: Decimal = field(default=Decimal(0))
     # the average maturity time of short positions.
-    short_average_maturity_time: float = field(default=0.0)
+    short_average_maturity_time: Decimal = field(default=Decimal(0))
     # the amount of base paid by outstanding longs.
     long_base_volume: float = field(default=0.0)
     # the amount of base paid to outstanding shorts.

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -340,7 +340,7 @@ class Market(
                 )
             elif agent_action.action_type == hyperdrive_actions.MarketActionType.CLOSE_LONG:  # sell to close long
                 # TODO: python 3.10 includes TypeGuard which properly avoids issues when using Optional type
-                mint_time = float(agent_action.mint_time or 0)
+                mint_time = Decimal(agent_action.mint_time or 0)
                 market_deltas, agent_deltas = self.close_long(
                     agent_wallet=agent_action.wallet,
                     bond_amount=agent_action.trade_amount,  # in bonds: that's the thing in your wallet you want to sell
@@ -353,7 +353,7 @@ class Market(
                 )
             elif agent_action.action_type == hyperdrive_actions.MarketActionType.CLOSE_SHORT:  # buy PT to close short
                 # TODO: python 3.10 includes TypeGuard which properly avoids issues when using Optional type
-                mint_time = float(agent_action.mint_time or 0)
+                mint_time = Decimal(agent_action.mint_time or 0)
                 open_share_price = agent_action.wallet.shorts[mint_time].open_share_price
                 market_deltas, agent_deltas = self.close_short(
                     agent_wallet=agent_action.wallet,

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -415,7 +415,7 @@ class Market(
         )
         agent_deltas = wallet.Wallet(
             address=wallet_address,
-            balance=-types.Quantity(amount=contribution, unit=types.TokenType.BASE),
+            balance=-types.Quantity(amount=Decimal(contribution), unit=types.TokenType.BASE),
             lp_tokens=self.market_state.share_price * share_reserves + bond_reserves,
         )
         self.update_market(market_deltas)
@@ -443,7 +443,7 @@ class Market(
     def close_short(
         self,
         agent_wallet: wallet.Wallet,
-        open_share_price: Decimals,
+        open_share_price: Decimal,
         bond_amount: Decimal,
         mint_time: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -38,9 +38,9 @@ class Checkpoint:
     def __setitem__(self, key, value):
         return setattr(self, key, value)
 
-    share_price: float = field(default=0.0)
-    long_base_volume: float = field(default=0.0)
-    short_base_volume: float = field(default=0.0)
+    share_price: Decimal = field(default_factory=Decimal)
+    long_base_volume: Decimal = field(default_factory=Decimal)
+    short_base_volume: Decimal = field(default_factory=Decimal)
 
 
 @types.freezable(frozen=False, no_new_attribs=False)
@@ -576,7 +576,7 @@ class Market(
         # divide the result by 365 again to get years
         return latest_checkpoint / 365
 
-    def apply_checkpoint(self, checkpoint_time: float, share_price: float) -> float:
+    def apply_checkpoint(self, checkpoint_time: float, share_price: Decimal) -> float:
         """Creates a new checkpoint if necessary and closes matured positions.
 
         Parameters

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -52,9 +52,9 @@ class MarketState(base_market.BaseMarketState):
     ----------
     lp_total_supply: float
         Amount of lp tokens
-    share_reserves: float
+    share_reserves: Decimal
         Quantity of shares stored in the market
-    bond_reserves: float
+    bond_reserves: Decimal
         Quantity of bonds stored in the market
     base_buffer: float
         Base amount set aside to account for open longs
@@ -62,10 +62,10 @@ class MarketState(base_market.BaseMarketState):
         Bond amount set aside to account for open shorts
     variable_apr: float
         apr of underlying yield-bearing source
-    share_price: float
+    share_price: Decimal
         ratio of value of base & shares that are stored in the underlying vault,
         i.e. share_price = base_value / share_value
-    init_share_price: float
+    init_share_price: Decimal
         share price at pool initialization
     trade_fee_percent : float
         The percentage of the difference between the amount paid without
@@ -94,8 +94,8 @@ class MarketState(base_market.BaseMarketState):
 
     # share price
     variable_apr: float = field(default=0.0)
-    share_price: float = field(default=1.0)
-    init_share_price: float = field(default=1.0)
+    share_price: Decimal = field(default=Decimal(0))
+    init_share_price: Decimal = field(default=Decimal(0))
 
     # fee percents
     trade_fee_percent: float = field(default=0.0)

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -398,7 +398,7 @@ class Market(
         """Market Deltas so that an LP can initialize the market"""
         if self.market_state.share_reserves > 0 or self.market_state.bond_reserves > 0:
             raise AssertionError("The market appears to already be initialized.")
-        share_reserves = contribution / self.market_state.share_price
+        share_reserves = Decimal(contribution) / self.market_state.share_price
         bond_reserves = self.pricing_model.calc_initial_bond_reserves(
             target_apr=target_apr,
             time_remaining=self.position_duration,
@@ -409,7 +409,7 @@ class Market(
             ),
         )
         market_deltas = hyperdrive_actions.MarketDeltas(
-            d_base_asset=contribution,
+            d_base_asset=Decimal(contribution),
             d_bond_asset=bond_reserves,
             d_lp_total_supply=self.market_state.share_price * share_reserves + bond_reserves,
         )

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -56,7 +56,7 @@ class MarketState(base_market.BaseMarketState):
         Quantity of shares stored in the market
     bond_reserves: Decimal
         Quantity of bonds stored in the market
-    base_buffer: float
+    base_buffer: Decimal
         Base amount set aside to account for open longs
     bond_buffer: float
         Bond amount set aside to account for open shorts
@@ -102,17 +102,17 @@ class MarketState(base_market.BaseMarketState):
     redemption_fee_percent: float = field(default=0.0)
 
     # The amount of longs that are still open.
-    longs_outstanding: float = field(default=0.0)
+    longs_outstanding: Decimal = field(default=Decimal(0))
     # the amount of shorts that are still open.
-    shorts_outstanding: float = field(default=0.0)
+    shorts_outstanding: Decimal = field(default=Decimal(0))
     # the average maturity time of long positions.
     long_average_maturity_time: Decimal = field(default=Decimal(0))
     # the average maturity time of short positions.
     short_average_maturity_time: Decimal = field(default=Decimal(0))
     # the amount of base paid by outstanding longs.
-    long_base_volume: float = field(default=0.0)
+    long_base_volume: Decimal = field(default=Decimal(0))
     # the amount of base paid to outstanding shorts.
-    short_base_volume: float = field(default=0.0)
+    short_base_volume: Decimal = field(default=Decimal(0))
     # time delimited checkpoints
     checkpoints: defaultdict[float, Checkpoint] = field(default_factory=lambda: defaultdict(Checkpoint))
     # time between checkpoints, defaults to 1 day

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -6,6 +6,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Union
+from decimal import Decimal
 
 import numpy as np
 
@@ -84,8 +85,8 @@ class MarketState(base_market.BaseMarketState):
     lp_total_supply: float = field(default=0.0)
 
     # trading reserves
-    share_reserves: float = field(default=0.0)
-    bond_reserves: float = field(default=0.0)
+    share_reserves: Decimal = field(default=Decimal(0))
+    bond_reserves: Decimal = field(default=Decimal(0))
 
     # trading buffers
     base_buffer: float = field(default=0.0)

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -236,7 +236,7 @@ class Market(
         return self.position_duration.days / 365
 
     @property
-    def fixed_apr(self) -> float:
+    def fixed_apr(self) -> Decimal:
         """Returns the current market apr"""
         # calc_apr_from_spot_price will throw an error if share_reserves <= zero
         # TODO: Negative values should never happen, but do because of rounding errors.
@@ -244,7 +244,7 @@ class Market(
         # issue #146
 
         if self.market_state.share_reserves <= 0:  # market is empty; negative value likely due to rounding error
-            return np.nan
+            return Decimal(np.nan)
         return price_utils.calc_apr_from_spot_price(price=self.spot_price, time_remaining=self.position_duration)
 
     @property
@@ -466,7 +466,7 @@ class Market(
     def open_long(
         self,
         agent_wallet: wallet.Wallet,
-        base_amount: float,
+        base_amount: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Calculate the deltas from opening a long and then update the agent wallet & market state"""
         # create/update the checkpoint
@@ -485,7 +485,7 @@ class Market(
     def close_long(
         self,
         agent_wallet: wallet.Wallet,
-        bond_amount: float,
+        bond_amount: Decimal,
         mint_time: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Calculate the deltas from closing a long and then update the agent wallet & market state"""
@@ -506,7 +506,7 @@ class Market(
     def add_liquidity(
         self,
         agent_wallet: wallet.Wallet,
-        bond_amount: float,
+        bond_amount: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Computes new deltas for bond & share reserves after liquidity is added"""
         self.apply_checkpoint(self.latest_checkpoint_time, self.market_state.share_price)
@@ -522,7 +522,7 @@ class Market(
     def remove_liquidity(
         self,
         agent_wallet: wallet.Wallet,
-        bond_amount: float,
+        bond_amount: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Computes new deltas for bond & share reserves after liquidity is removed"""
         self.apply_checkpoint(self.latest_checkpoint_time, self.market_state.share_price)

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -128,8 +128,8 @@ class MarketState(base_market.BaseMarketState):
     init_share_price: Decimal = field(default=Decimal(0))
 
     # fee percents
-    trade_fee_percent: float = field(default=0.0)
-    redemption_fee_percent: float = field(default=0.0)
+    trade_fee_percent: Decimal = field(default=Decimal(0))
+    redemption_fee_percent: Decimal = field(default=Decimal(0))
 
     # The amount of longs that are still open.
     longs_outstanding: Decimal = field(default=Decimal(0))

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -89,7 +89,7 @@ class MarketState(base_market.BaseMarketState):
     bond_reserves: Decimal = field(default=Decimal(0))
 
     # trading buffers
-    base_buffer: float = field(default=0.0)
+    base_buffer: Decimal = field(default=Decimal(0))
     bond_buffer: float = field(default=0.0)
 
     # share price

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -424,7 +424,7 @@ class Market(
     def open_short(
         self,
         agent_wallet: wallet.Wallet,
-        bond_amount: float,
+        bond_amount: Decimal,
     ) -> tuple[hyperdrive_actions.MarketDeltas, wallet.Wallet]:
         """Calculates the deltas from opening a short and then updates the agent wallet & market state"""
         # create/update the checkpoint

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -86,7 +86,7 @@ class PricingModel(ABC):
 
     def calc_initial_bond_reserves(
         self,
-        target_apr: Decimal,
+        target_apr: float,
         time_remaining: time.StretchedTime,
         market_state: hyperdrive_market.MarketState,
     ) -> Decimal:
@@ -95,7 +95,7 @@ class PricingModel(ABC):
 
         Parameters
         ----------
-        target_apr : Decimal
+        target_apr : float
             Target fixed APR in decimal units (for example, 5% APR would be 0.05)
         time_remaining : StretchedTime
             Amount of time left until bond maturity
@@ -120,7 +120,8 @@ class PricingModel(ABC):
         annualized_time = time.norm_days(time_remaining.days, Decimal(365))
         # y = z/2 * (mu * (1 + rt)**(1/tau) - c)
         return (market_state.share_reserves / 2) * (
-            market_state.init_share_price * (1 + target_apr * annualized_time) ** (1 / time_remaining.stretched_time)
+            market_state.init_share_price
+            * (1 + Decimal(target_apr) * annualized_time) ** (1 / time_remaining.stretched_time)
             - market_state.share_price
         )
 

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -221,7 +221,7 @@ class PricingModel(ABC):
         self,
         market_state: hyperdrive_market.MarketState,
         time_remaining: time.StretchedTime,
-    ) -> tuple[float, float]:
+    ) -> tuple[Decimal, Decimal]:
         r"""
         Calculates the maximum long the market can support
 
@@ -233,16 +233,16 @@ class PricingModel(ABC):
         ----------
         market_state : MarketState
             The reserves and share prices of the pool
-        fee_percent : float
+        fee_percent : Decimal
             The fee percent charged by the market
         time_remaining : StretchedTime
             The time remaining for the asset (incorporates time stretch)
 
         Returns
         -------
-        float
+        Decimal
             The maximum amount of base that can be used to purchase bonds.
-        float
+        Decimal
             The maximum amount of bonds that can be purchased.
         """
         base = self.calc_in_given_out(
@@ -255,7 +255,7 @@ class PricingModel(ABC):
             market_state=market_state,
             time_remaining=time_remaining,
         ).breakdown.with_fee
-        return (base, bonds)
+        return base, bonds
 
     def get_max_short(
         self,

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -261,7 +261,7 @@ class PricingModel(ABC):
         self,
         market_state: hyperdrive_market.MarketState,
         time_remaining: time.StretchedTime,
-    ) -> tuple[float, float]:
+    ) -> tuple[Decimal, Decimal]:
         r"""
         Calculates the maximum short the market can support using the bisection
         method.
@@ -280,9 +280,9 @@ class PricingModel(ABC):
 
         Returns
         -------
-        float
+        Decimal
             The maximum amount of base that can be used to short bonds.
-        float
+        Decimal
             The maximum amount of bonds that can be shorted.
         """
         bonds = self.calc_in_given_out(
@@ -298,7 +298,7 @@ class PricingModel(ABC):
             market_state=market_state,
             time_remaining=time_remaining,
         ).breakdown.with_fee
-        return (base, bonds)
+        return base, bonds
 
     def calc_time_stretch(self, apr) -> float:
         """Returns fixed time-stretch value based on current apr (as a decimal)"""

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -169,36 +169,6 @@ class PricingModel(ABC):
         self,
         market_state: hyperdrive_market.MarketState,
         time_remaining: time.StretchedTime,
-    ) -> float:
-        r"""Calculates the spot price of base in terms of bonds.
-        The spot price is defined as:
-
-        .. math::
-            \begin{align}
-                p &= (\frac{y + s}{\mu z})^{-\tau} \\
-                  &= (\frac{\mu z}{y + s})^{\tau}
-            \end{align}
-
-        Parameters
-        ----------
-        market_state: MarketState
-            The reserves and prices in the pool.
-        time_remaining : StretchedTime
-            The time remaining for the asset (uses time stretch).
-
-        Returns
-        -------
-        float
-            The spot price of principal tokens.
-        """
-        return float(
-            self._calc_spot_price_from_reserves_high_precision(market_state=market_state, time_remaining=time_remaining)
-        )
-
-    def _calc_spot_price_from_reserves_high_precision(
-        self,
-        market_state: hyperdrive_market.MarketState,
-        time_remaining: time.StretchedTime,
     ) -> Decimal:
         r"""Calculates the current market spot price of base in terms of bonds.
         This variant returns the result in a high precision format.

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -189,11 +189,11 @@ class PricingModel(ABC):
         Decimal
             The spot price of principal tokens.
         """
-        init_share_price = Decimal(market_state.init_share_price)  # mu
-        share_reserves = Decimal(market_state.share_reserves)  # z
-        bond_reserves = Decimal(market_state.bond_reserves)  # y
-        lp_total_supply = Decimal(market_state.lp_total_supply)  # s
-        tau = Decimal(time_remaining.stretched_time)  # tau = days / duration / time_stretch
+        init_share_price = market_state.init_share_price  # mu
+        share_reserves = market_state.share_reserves  # z
+        bond_reserves = market_state.bond_reserves  # y
+        lp_total_supply = market_state.lp_total_supply  # s
+        tau = time_remaining.stretched_time  # tau = days / duration / time_stretch
         # p = ((mu * z) / (y + s))^(tau)
         return ((init_share_price * share_reserves) / (bond_reserves + lp_total_supply)) ** tau
 

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -201,8 +201,8 @@ class PricingModel(ABC):
         self,
         market_state: hyperdrive_market.MarketState,
         time_remaining: time.StretchedTime,
-    ) -> float:
-        r"""Returns the apr given reserve amounts
+    ) -> Decimal:
+        r"""Returns the apr for given reserve amounts
 
         Parameters
         ----------
@@ -210,6 +210,11 @@ class PricingModel(ABC):
             The reserves and share prices of the pool
         time_remaining : StretchedTime
             The expiry time for the asset
+
+        Returns
+        -------
+        Decimal
+            The calculated APR
         """
         spot_price = self.calc_spot_price_from_reserves(
             market_state,

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -86,10 +86,10 @@ class PricingModel(ABC):
 
     def calc_initial_bond_reserves(
         self,
-        target_apr: float,
+        target_apr: Decimal,
         time_remaining: time.StretchedTime,
         market_state: hyperdrive_market.MarketState,
-    ) -> float:
+    ) -> Decimal:
         """Returns the assumed bond (i.e. token asset) reserve amounts given
         the share (i.e. base asset) reserves and APR for an initialized market
 
@@ -117,7 +117,7 @@ class PricingModel(ABC):
         """
         # Only want to renormalize time for APR ("annual", so hard coded to 365)
         # Don't want to renormalize stretched time
-        annualized_time = time.norm_days(time_remaining.days, 365)
+        annualized_time = time.norm_days(time_remaining.days, Decimal(365))
         # y = z/2 * (mu * (1 + rt)**(1/tau) - c)
         return (market_state.share_reserves / 2) * (
             market_state.init_share_price * (1 + target_apr * annualized_time) ** (1 / time_remaining.stretched_time)

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -95,22 +95,22 @@ class PricingModel(ABC):
 
         Parameters
         ----------
-        target_apr : float
+        target_apr : Decimal
             Target fixed APR in decimal units (for example, 5% APR would be 0.05)
         time_remaining : StretchedTime
             Amount of time left until bond maturity
         market_state : MarketState
             MarketState object; the following attributes are used:
-                share_reserves : float
+                share_reserves : Decimal
                     Base asset reserves in the pool
-                init_share_price : float
+                init_share_price : Decimal
                     Original share price when the pool started
-                share_price : float
+                share_price : Decimal
                     Current share price
 
         Returns
         -------
-        float
+        Decimal
             The expected amount of bonds (token asset) in the pool, given the inputs
 
         .. todo:: test_market.test_initialize_market uses this, but this should also have a unit test

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -130,7 +130,7 @@ class PricingModel(ABC):
         target_apr: float,
         time_remaining: time.StretchedTime,
         market_state: hyperdrive_market.MarketState,
-    ) -> float:
+    ) -> Decimal:
         """Returns the assumed bond (i.e. token asset) reserve amounts given
         the share (i.e. base asset) reserves and APR
 
@@ -151,15 +151,15 @@ class PricingModel(ABC):
 
         Returns
         -------
-        float
+        Decimal
             The expected amount of bonds (token asset) in the pool, given the inputs
 
         .. todo:: Test this function
         """
         # Only want to renormalize time for APR ("annual", so hard coded to 365)
-        annualized_time = time.norm_days(time_remaining.days, 365)
+        annualized_time = time.norm_days(time_remaining.days, Decimal(365))
         # (1 + r * t) ** (1 / tau)
-        interest_factor = (1 + target_apr * annualized_time) ** (1 / time_remaining.stretched_time)
+        interest_factor = (1 + Decimal(target_apr) * annualized_time) ** (1 / time_remaining.stretched_time)
         # mu * z * (1 + apr * t) ** (1 / tau) - l
         return (
             market_state.init_share_price * market_state.share_reserves * interest_factor - market_state.lp_total_supply

--- a/elfpy/pricing_models/trades.py
+++ b/elfpy/pricing_models/trades.py
@@ -1,6 +1,6 @@
 """Trade related classes and functions"""
 from dataclasses import dataclass
-
+from decimal import Decimal
 
 import elfpy.types as types
 import elfpy.agents.agent as agent
@@ -30,10 +30,10 @@ class TradeBreakdown:
         always in terms of bonds or base.
     """
 
-    without_fee_or_slippage: float
-    with_fee: float
-    without_fee: float
-    fee: float
+    without_fee_or_slippage: Decimal
+    with_fee: Decimal
+    without_fee: Decimal
+    fee: Decimal
 
 
 @types.freezable(frozen=True, no_new_attribs=True)

--- a/elfpy/pricing_models/yieldspace.py
+++ b/elfpy/pricing_models/yieldspace.py
@@ -60,7 +60,7 @@ class YieldspacePricingModel(PricingModel):
         else:  # initial case where we have 0 share reserves or final case where it has been removed
             lp_out = d_shares
         # TODO: Move this calculation to a helper function.
-        annualized_time = time.norm_days(time_remaining.days, 365)
+        annualized_time = time.norm_days(time_remaining.days, Decimal(365))
         d_bonds = (market_state.share_reserves + d_shares) / 2 * (
             market_state.init_share_price * (1 + rate * annualized_time) ** (1 / time_remaining.stretched_time)
             - market_state.share_price
@@ -131,7 +131,7 @@ class YieldspacePricingModel(PricingModel):
             market_state.share_reserves - market_state.base_buffer / market_state.share_price
         )
         # TODO: Move this calculation to a helper function.
-        annualized_time = time.norm_days(time_remaining.days, 365)
+        annualized_time = time.norm_days(time_remaining.days, Decimal(365))
         d_bonds = (market_state.share_reserves - d_shares) / 2 * (
             market_state.init_share_price * (1 + rate * annualized_time) ** (1 / time_remaining.stretched_time)
             - market_state.share_price
@@ -157,14 +157,14 @@ class YieldspacePricingModel(PricingModel):
         d_shares = d_base / market_state.share_price
         # TODO: Move this calculation to a helper function.
         # rate is an APR, which is annual, so we normalize time by 365 to correct for units
-        annualized_time = time.norm_days(time_remaining.days, 365)
+        annualized_time = time.norm_days(time_remaining.days, Decimal(365))
 
         d_bonds = ((market_state.share_reserves - d_shares) / 2) * (
             market_state.init_share_price * (1 + rate * annualized_time) ** (1 / time_remaining.stretched_time)
             - market_state.share_price
         ) - market_state.bond_reserves
 
-        annualized_time = time.norm_days(time_remaining.days, 365)
+        annualized_time = time.norm_days(time_remaining.days, Decimal(365))
         logging.debug(
             (
                 "inputs:\n\tlp_in=%g,\n\tshare_reserves=%d, "
@@ -308,10 +308,7 @@ class YieldspacePricingModel(PricingModel):
         share_reserves = Decimal(market_state.share_reserves)
         bond_reserves = Decimal(market_state.bond_reserves)
         lp_total_supply = Decimal(market_state.lp_total_supply)
-        spot_price = self._calc_spot_price_from_reserves_high_precision(
-            market_state,
-            time_remaining,
-        )
+        spot_price = self.calc_spot_price_from_reserves(market_state, time_remaining)
         out_amount = Decimal(out.amount)
         trade_fee_percent = Decimal(market_state.trade_fee_percent)
         if out.unit == types.TokenType.BASE:
@@ -556,10 +553,7 @@ class YieldspacePricingModel(PricingModel):
         share_reserves = Decimal(market_state.share_reserves)
         bond_reserves = Decimal(market_state.bond_reserves)
         lp_total_supply = Decimal(market_state.lp_total_supply)
-        spot_price = self._calc_spot_price_from_reserves_high_precision(
-            market_state,
-            time_remaining,
-        )
+        spot_price = self.calc_spot_price_from_reserves(market_state, time_remaining)
         in_amount = Decimal(in_.amount)
         trade_fee_percent = Decimal(market_state.trade_fee_percent)
         if in_.unit == types.TokenType.BASE:

--- a/elfpy/pricing_models/yieldspace.py
+++ b/elfpy/pricing_models/yieldspace.py
@@ -40,11 +40,11 @@ class YieldspacePricingModel(PricingModel):
 
     def calc_lp_out_given_tokens_in(
         self,
-        d_base: float,
-        rate: float,
+        d_base: Decimal,
+        rate: Decimal,
         market_state: hyperdrive_market.MarketState,
         time_remaining: time.StretchedTime,
-    ) -> tuple[float, float, float]:
+    ) -> tuple[Decimal, Decimal, Decimal]:
         r"""Computes the amount of LP tokens to be minted for a given amount of base asset
 
         .. math::
@@ -116,11 +116,11 @@ class YieldspacePricingModel(PricingModel):
     # TODO: Delete this function from here & base? It is not used or tested.
     def calc_lp_in_given_tokens_out(
         self,
-        d_base: float,
-        rate: float,
+        d_base: Decimal,
+        rate: Decimal,
         market_state: hyperdrive_market.MarketState,
         time_remaining: time.StretchedTime,
-    ) -> tuple[float, float, float]:
+    ) -> tuple[Decimal, Decimal, Decimal]:
         r"""Computes the amount of LP tokens to be minted for a given amount of base asset
 
         .. math::
@@ -140,11 +140,11 @@ class YieldspacePricingModel(PricingModel):
 
     def calc_tokens_out_given_lp_in(
         self,
-        lp_in: float,
-        rate: float,
+        lp_in: Decimal,
+        rate: Decimal,
         market_state: hyperdrive_market.MarketState,
         time_remaining: time.StretchedTime,
-    ) -> tuple[float, float, float]:
+    ) -> tuple[Decimal, Decimal, Decimal]:
         """Calculate how many tokens should be returned for a given lp addition
 
         .. todo:: add test for this function; improve function documentation w/ parameters, returns, and equations used
@@ -276,18 +276,30 @@ class YieldspacePricingModel(PricingModel):
 
         Returns
         -------
-        float
-            The amount the agent pays without fees or slippage. The units
-            are always in terms of bonds or base.
-        float
-            The amount the agent pays with fees and slippage. The units are
-            always in terms of bonds or base.
-        float
-            The amount the agent pays with slippage and no fees. The units are
-            always in terms of bonds or base.
-        float
-            The fee the agent pays. The units are always in terms of bonds or
-            base.
+        trades.TradeResult
+            contains all of the results of a trade, including the following
+        user_result: AgentTradeResult
+            contains the results of a trade for the agent, consisting of:
+                d_base: Decimal
+                d_bonds: Decimal
+        market_result = MarketActionResult
+            contains the results of a trade for the market, consisting of:
+                d_base: Decimal
+                d_bonds: Decimal
+        breakdown = TradeBreakdown
+            contains detailed trade results straight from the pricing model, consisting of:
+                without_fee_or_slippage: float
+                    The amount the user pays without fees or slippage. The units
+                    are always in terms of bonds or base, depending on input.
+                with_fee: float
+                    The fee the user pays. The units are always in terms of bonds or
+                    base.
+                without_fee: float
+                    The amount the user pays with fees and slippage. The units are
+                    always in terms of bonds or base.
+                fee: float
+                    The amount the user pays with slippage and no fees. The units are
+                    always in terms of bonds or base.
         """
         # Calculate some common values up front
         time_elapsed = 1 - Decimal(time_remaining.stretched_time)
@@ -512,18 +524,30 @@ class YieldspacePricingModel(PricingModel):
 
         Returns
         -------
-        float
-            The amount the agent receives without fees or slippage. The units
-            are always in terms of bonds or base.
-        float
-            The amount the agent receives with fees and slippage. The units are
-            always in terms of bonds or base.
-        float
-            The amount the agent receives with slippage and no fees. The units are
-            always in terms of bonds or base.
-        float
-            The fee the agent pays. The units are always in terms of bonds or
-            base.
+        trades.TradeResult
+            contains all of the results of a trade, including the following
+        user_result: AgentTradeResult
+            contains the results of a trade for the agent, consisting of:
+                d_base: Decimal
+                d_bonds: Decimal
+        market_result = MarketActionResult
+            contains the results of a trade for the market, consisting of:
+                d_base: Decimal
+                d_bonds: Decimal
+        breakdown = TradeBreakdown
+            contains detailed trade results straight from the pricing model, consisting of:
+                without_fee_or_slippage: float
+                    The amount the user pays without fees or slippage. The units
+                    are always in terms of bonds or base, depending on input.
+                with_fee: float
+                    The fee the user pays. The units are always in terms of bonds or
+                    base.
+                without_fee: float
+                    The amount the user pays with fees and slippage. The units are
+                    always in terms of bonds or base.
+                fee: float
+                    The amount the user pays with slippage and no fees. The units are
+                    always in terms of bonds or base.
         """
         # Calculate some common values up front
         time_elapsed = 1 - Decimal(time_remaining.stretched_time)

--- a/elfpy/pricing_models/yieldspace.py
+++ b/elfpy/pricing_models/yieldspace.py
@@ -356,11 +356,11 @@ class YieldspacePricingModel(PricingModel):
             # Create the agent and market trade results.
             user_result = AgentTradeResult(
                 d_base=out.amount,
-                d_bonds=float(-with_fee),
+                d_bonds=-with_fee,
             )
             market_result = hyperdrive_actions.MarketActionResult(
                 d_base=-out.amount,
-                d_bonds=float(with_fee),
+                d_bonds=with_fee,
             )
         elif out.unit == types.TokenType.PT:
             d_bonds = out_amount
@@ -415,11 +415,11 @@ class YieldspacePricingModel(PricingModel):
             with_fee = without_fee + fee
             # Create the agent and market trade results.
             user_result = AgentTradeResult(
-                d_base=float(-with_fee),
+                d_base=-with_fee,
                 d_bonds=out.amount,
             )
             market_result = hyperdrive_actions.MarketActionResult(
-                d_base=float(with_fee),
+                d_base=with_fee,
                 d_bonds=-out.amount,
             )
         else:
@@ -431,10 +431,10 @@ class YieldspacePricingModel(PricingModel):
             user_result=user_result,
             market_result=market_result,
             breakdown=trades.TradeBreakdown(
-                without_fee_or_slippage=float(without_fee_or_slippage),
-                with_fee=float(with_fee),
-                without_fee=float(without_fee),
-                fee=float(fee),
+                without_fee_or_slippage=without_fee_or_slippage,
+                with_fee=with_fee,
+                without_fee=without_fee,
+                fee=fee,
             ),
         )
 
@@ -579,11 +579,11 @@ class YieldspacePricingModel(PricingModel):
             # Create the agent and market trade results.
             user_result = AgentTradeResult(
                 d_base=-in_.amount,
-                d_bonds=float(with_fee),
+                d_bonds=with_fee,
             )
             market_result = hyperdrive_actions.MarketActionResult(
                 d_base=in_.amount,
-                d_bonds=float(-with_fee),
+                d_bonds=-with_fee,
             )
         elif in_.unit == types.TokenType.PT:
             d_bonds = in_amount
@@ -631,11 +631,11 @@ class YieldspacePricingModel(PricingModel):
             with_fee = without_fee - fee
             # Create the agent and market trade results.
             user_result = AgentTradeResult(
-                d_base=float(with_fee),
+                d_base=with_fee,
                 d_bonds=-in_.amount,
             )
             market_result = hyperdrive_actions.MarketActionResult(
-                d_base=float(-with_fee),
+                d_base=-with_fee,
                 d_bonds=in_.amount,
             )
         else:
@@ -647,10 +647,10 @@ class YieldspacePricingModel(PricingModel):
             user_result=user_result,
             market_result=market_result,
             breakdown=trades.TradeBreakdown(
-                without_fee_or_slippage=float(without_fee_or_slippage),
-                with_fee=float(with_fee),
-                without_fee=float(without_fee),
-                fee=float(fee),
+                without_fee_or_slippage=without_fee_or_slippage,
+                with_fee=with_fee,
+                without_fee=without_fee,
+                fee=fee,
             ),
         )
 

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -63,29 +63,31 @@ class StretchedTime:
         )
 
 
-def get_years_remaining(market_time: float, mint_time: float, position_duration_years: float) -> float:
+def get_years_remaining(market_time: Decimal, mint_time: Decimal, position_duration_years: Decimal) -> Decimal:
     r"""Get the time remaining in years on a token
 
     Parameters
     ----------
-    market_time : float
+    market_time : Decimal
         Time that has elapsed in the given market, in years
-    mint_time : float
+    mint_time : Decimal
         Time at which the token in question was minted, relative to market_time,
         in yearss. Should be less than market_time.
-    position_duration_years: float
+    position_duration_years: Decimal
         Total duration of the token's term, in years
 
     Returns
     -------
-    float
+    Decimal
         Time left until token maturity, in years
     """
     if mint_time > market_time:
         raise ValueError(f"elfpy.utils.time.get_years_remaining: ERROR: {mint_time=} must be less than {market_time=}.")
     years_elapsed = market_time - mint_time
     # if we are closing after the position duration has completed, then just set time_remaining to zero
-    return np.maximum(position_duration_years - years_elapsed, 0)
+    return (
+        position_duration_years - years_elapsed if position_duration_years - years_elapsed > Decimal(0) else Decimal(0)
+    )
 
 
 def norm_days(days: Decimal, normalizing_constant: Decimal = Decimal(365)) -> Decimal:

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -130,7 +130,7 @@ def days_to_time_remaining(
         Time remaining until term maturity, in normalized and stretched time
     """
     normed_days_remaining = norm_days(days_remaining, normalizing_constant)
-    return normed_days_remaining / Decimal(time_stretch)
+    return normed_days_remaining / time_stretch
 
 
 def time_to_days_remaining(time_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365) -> float:

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -95,14 +95,14 @@ def norm_days(days: Decimal, normalizing_constant: Decimal = Decimal(365)) -> De
 
     Parameters
     ----------
-    days : float
+    days : Decimal
         Amount of days to normalize
-    normalizing_constant : float
+    normalizing_constant : Decimal
         Amount of days to use as a normalization factor. Defaults to 365
 
     Returns
     -------
-    float
+    Decimal
         Amount of days provided, converted to fractions of a year
     """
     return days / normalizing_constant

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -1,6 +1,7 @@
 """Helper functions for converting time units"""
 
 from dataclasses import dataclass
+from decimal import Decimal
 
 import numpy as np
 
@@ -88,7 +89,7 @@ def get_years_remaining(market_time: float, mint_time: float, position_duration_
     return time_remaining
 
 
-def norm_days(days: float, normalizing_constant: float = 365) -> float:
+def norm_days(days: float, normalizing_constant: float = 365) -> Decimal:
     r"""Returns days normalized, with a default assumption of a year-long scale
 
     Parameters
@@ -103,10 +104,12 @@ def norm_days(days: float, normalizing_constant: float = 365) -> float:
     float
         Amount of days provided, converted to fractions of a year
     """
-    return days / normalizing_constant
+    return Decimal(days) / Decimal(normalizing_constant)
 
 
-def days_to_time_remaining(days_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365) -> float:
+def days_to_time_remaining(
+    days_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365
+) -> Decimal:
     r"""Converts remaining pool length in days to normalized and stretched time
 
     Parameters
@@ -126,7 +129,7 @@ def days_to_time_remaining(days_remaining: float, time_stretch: float = 1, norma
         Time remaining until term maturity, in normalized and stretched time
     """
     normed_days_remaining = norm_days(days_remaining, normalizing_constant)
-    return normed_days_remaining / time_stretch
+    return normed_days_remaining / Decimal(time_stretch)
 
 
 def time_to_days_remaining(time_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365) -> float:

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -12,16 +12,16 @@ import elfpy.types as types
 class BlockTime:
     r"""Global time."""
 
-    time: Decimal = 0  # time in years
-    block_number: float = 0
-    step_size: Decimal = Decimal(1 / 365)  # defaults to 1 day
+    time: float = 0  # time in years
+    block_number: int = 0
+    step_size: float = 1 / 365  # defaults to 1 day
 
     @property
-    def time_in_seconds(self) -> Decimal:
+    def time_in_seconds(self) -> float:
         """1 year = 31,556,952 seconds"""
         return self.time * 31_556_952
 
-    def tick(self, delta_years: Decimal) -> None:
+    def tick(self, delta_years: float) -> None:
         """ticks the time by delta_time amount"""
         self.time += delta_years
 
@@ -29,11 +29,11 @@ class BlockTime:
         """ticks the time by step_size"""
         self.time += self.step_size
 
-    def set_time(self, time: Decimal) -> None:
+    def set_time(self, time: float) -> None:
         """Sets the time"""
         self.time = time
 
-    def set_step_size(self, step_size: Decimal) -> None:
+    def set_step_size(self, step_size: float) -> None:
         """Sets the step_size for tick"""
         self.step_size = step_size
 

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -105,7 +105,7 @@ def norm_days(days: Decimal, normalizing_constant: Decimal = Decimal(365)) -> De
     float
         Amount of days provided, converted to fractions of a year
     """
-    return Decimal(days) / Decimal(normalizing_constant)
+    return days / normalizing_constant
 
 
 def days_to_time_remaining(

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -45,9 +45,9 @@ class StretchedTime:
 
     .. todo:: Improve this constructor so that StretchedTime can be constructed from years.
     """
-    days: Decimal
-    time_stretch: Decimal
-    normalizing_constant: Decimal
+    days: float
+    time_stretch: float
+    normalizing_constant: float
 
     @property
     def stretched_time(self):
@@ -90,43 +90,41 @@ def get_years_remaining(market_time: Decimal, mint_time: Decimal, position_durat
     )
 
 
-def norm_days(days: Decimal, normalizing_constant: Decimal = Decimal(365)) -> Decimal:
+def norm_days(days: float, normalizing_constant: float = 365) -> float:
     r"""Returns days normalized, with a default assumption of a year-long scale
 
     Parameters
     ----------
-    days : Decimal
+    days : float
         Amount of days to normalize
-    normalizing_constant : Decimal
+    normalizing_constant : float
         Amount of days to use as a normalization factor. Defaults to 365
 
     Returns
     -------
-    Decimal
+    float
         Amount of days provided, converted to fractions of a year
     """
     return days / normalizing_constant
 
 
-def days_to_time_remaining(
-    days_remaining: Decimal, time_stretch: Decimal = Decimal(1), normalizing_constant: Decimal = Decimal(365)
-) -> Decimal:
+def days_to_time_remaining(days_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365) -> float:
     r"""Converts remaining pool length in days to normalized and stretched time
 
     Parameters
     ----------
-    days_remaining : Decimal
+    days_remaining : float
         Time left until term maturity, in days
-    time_stretch : Decimal
+    time_stretch : float
         Amount of time units (in terms of a normalizing constant) to use for stretching time, for calculations
         Defaults to 1
-    normalizing_constant : Decimal
+    normalizing_constant : float
         Amount of days to use as a normalization factor
         Defaults to 365
 
     Returns
     -------
-    Decimal
+    float
         Time remaining until term maturity, in normalized and stretched time
     """
     normed_days_remaining = norm_days(days_remaining, normalizing_constant)

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -12,16 +12,16 @@ import elfpy.types as types
 class BlockTime:
     r"""Global time."""
 
-    time: float = 0  # time in years
+    time: Decimal = 0  # time in years
     block_number: float = 0
-    step_size: float = 1 / 365  # defaults to 1 day
+    step_size: Decimal = Decimal(1 / 365)  # defaults to 1 day
 
     @property
-    def time_in_seconds(self) -> float:
+    def time_in_seconds(self) -> Decimal:
         """1 year = 31,556,952 seconds"""
         return self.time * 31_556_952
 
-    def tick(self, delta_years: float) -> None:
+    def tick(self, delta_years: Decimal) -> None:
         """ticks the time by delta_time amount"""
         self.time += delta_years
 
@@ -29,11 +29,11 @@ class BlockTime:
         """ticks the time by step_size"""
         self.time += self.step_size
 
-    def set_time(self, time: float) -> None:
+    def set_time(self, time: Decimal) -> None:
         """Sets the time"""
         self.time = time
 
-    def set_step_size(self, step_size: float) -> None:
+    def set_step_size(self, step_size: Decimal) -> None:
         """Sets the step_size for tick"""
         self.step_size = step_size
 

--- a/elfpy/time/time.py
+++ b/elfpy/time/time.py
@@ -45,9 +45,9 @@ class StretchedTime:
 
     .. todo:: Improve this constructor so that StretchedTime can be constructed from years.
     """
-    days: float
-    time_stretch: float
-    normalizing_constant: float
+    days: Decimal
+    time_stretch: Decimal
+    normalizing_constant: Decimal
 
     @property
     def stretched_time(self):
@@ -85,11 +85,10 @@ def get_years_remaining(market_time: float, mint_time: float, position_duration_
         raise ValueError(f"elfpy.utils.time.get_years_remaining: ERROR: {mint_time=} must be less than {market_time=}.")
     years_elapsed = market_time - mint_time
     # if we are closing after the position duration has completed, then just set time_remaining to zero
-    time_remaining = np.maximum(position_duration_years - years_elapsed, 0)
-    return time_remaining
+    return np.maximum(position_duration_years - years_elapsed, 0)
 
 
-def norm_days(days: float, normalizing_constant: float = 365) -> Decimal:
+def norm_days(days: Decimal, normalizing_constant: Decimal = Decimal(365)) -> Decimal:
     r"""Returns days normalized, with a default assumption of a year-long scale
 
     Parameters
@@ -108,24 +107,24 @@ def norm_days(days: float, normalizing_constant: float = 365) -> Decimal:
 
 
 def days_to_time_remaining(
-    days_remaining: float, time_stretch: float = 1, normalizing_constant: float = 365
+    days_remaining: Decimal, time_stretch: Decimal = Decimal(1), normalizing_constant: Decimal = Decimal(365)
 ) -> Decimal:
     r"""Converts remaining pool length in days to normalized and stretched time
 
     Parameters
     ----------
-    days_remaining : float
+    days_remaining : Decimal
         Time left until term maturity, in days
-    time_stretch : float
+    time_stretch : Decimal
         Amount of time units (in terms of a normalizing constant) to use for stretching time, for calculations
         Defaults to 1
-    normalizing_constant : float
+    normalizing_constant : Decimal
         Amount of days to use as a normalization factor
         Defaults to 365
 
     Returns
     -------
-    float
+    Decimal
         Time remaining until term maturity, in normalized and stretched time
     """
     normed_days_remaining = norm_days(days_remaining, normalizing_constant)

--- a/elfpy/types.py
+++ b/elfpy/types.py
@@ -4,6 +4,7 @@ from enum import Enum
 from dataclasses import dataclass
 from functools import wraps
 from typing import Type, Any
+from decimal import Decimal
 
 
 def freezable(frozen: bool = False, no_new_attribs: bool = False) -> Type:
@@ -62,7 +63,7 @@ class TokenType(Enum):
 class Quantity:
     r"""An amount with a unit"""
 
-    amount: float
+    amount: Decimal
     unit: TokenType
 
     def __neg__(self):

--- a/elfpy/utils/price.py
+++ b/elfpy/utils/price.py
@@ -2,23 +2,24 @@
 from __future__ import annotations  # types will be strings by default in 3.11
 
 import elfpy.time as time
+from decimal import Decimal
 
 
 ### Spot Price and APR ###
-def calc_apr_from_spot_price(price: float, time_remaining: time.StretchedTime):
+def calc_apr_from_spot_price(price: Decimal, time_remaining: time.StretchedTime):
     r"""
     Returns the APR (decimal) given the current (positive) base asset price and the remaining pool duration
 
     Parameters
     ----------
-    price : float
+    price : Decimal
         Spot price of bonds in terms of base
     time_remaining : StretchedTime
         Time remaining until bond maturity, in years
 
     Returns
     -------
-    float
+    Decimal
         APR (decimal) calculated from the provided parameters
     """
     assert price > 0, (
@@ -29,7 +30,7 @@ def calc_apr_from_spot_price(price: float, time_remaining: time.StretchedTime):
         "utils.price.calc_apr_from_spot_price: ERROR: "
         f"time_remaining.normalized_time should be greater than zero, not {time_remaining.normalized_time}"
     )
-    annualized_time = time.norm_days(time_remaining.days, 365)
+    annualized_time = time.norm_days(time_remaining.days, Decimal(365))
     return (1 - price) / (price * annualized_time)  # r = ((1/p)-1)/t = (1-p)/(pt)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,7 @@
 norecursedirs = .git examples
 # shorter traceback format
 addopts = --tb=short
+report_passed = ✔
+report_passed_verbose = YASSS 🎉
+report_failed = 💥
+report_failed_verbose = FUCKITY FUCK 😱

--- a/requirements-3.11.txt
+++ b/requirements-3.11.txt
@@ -11,3 +11,4 @@ pytest
 scipy
 stochastic
 tomli
+pytest-custom-report

--- a/requirements-3.8.txt
+++ b/requirements-3.8.txt
@@ -11,3 +11,4 @@ pytest==3.6.4
 scipy==1.7.3
 stochastic>=0.6.0
 tomli==2.0.1
+pytest-custom-report>=1.01

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,0 +1,100 @@
+"""Close long market trade tests that match those being executed in the solidity repo"""
+import unittest
+
+import elfpy.agents.agent as agent
+import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
+import elfpy.pricing_models.hyperdrive as hyperdrive_pm
+import elfpy.time as time
+import elfpy.types as types
+
+
+# pylint: disable=too-many-arguments
+# pylint: disable=duplicate-code
+
+
+class TestPrecision(unittest.TestCase):
+    """
+    Tests precision
+    """
+
+    contribution: float = 500_000_000
+    target_apr: float = 0.05
+    term_length: int = 365
+    alice: agent.Agent
+    bob: agent.Agent
+    celine: agent.Agent
+    hyperdrive: hyperdrive_market.Market
+
+    def setUp(self):
+        """Set up agent, pricing model, & market for the subsequent tests.
+        This function is run before each test method.
+        """
+        self.alice = agent.Agent(wallet_address=0, budget=self.contribution)
+        self.bob = agent.Agent(wallet_address=1, budget=self.contribution)
+        block_time = time.BlockTime()
+        pricing_model = hyperdrive_pm.HyperdrivePricingModel()
+        market_state = hyperdrive_market.MarketState(
+            trade_fee_percent=0.0,
+            redemption_fee_percent=0.0,
+        )
+        self.hyperdrive = hyperdrive_market.Market(
+            pricing_model=pricing_model,
+            market_state=market_state,
+            position_duration=time.StretchedTime(
+                days=365, time_stretch=pricing_model.calc_time_stretch(self.target_apr), normalizing_constant=365
+            ),
+            block_time=block_time,
+        )
+        _, wallet_deltas = self.hyperdrive.initialize(self.alice.wallet.address, self.contribution, 0.05)
+        self.alice.wallet.update(wallet_deltas)
+
+    def verify_slippage(self, base_output, base_input):
+        self.assertLess(  # user gets less than what they put in
+            base_output,
+            base_input,
+            msg="ERROR: trade has no slippage",
+        )
+
+    def test_precision_long_open(self):
+        """Make sure we have slippage on a long open"""
+        base_amount = 10
+        self.bob.budget = base_amount
+        self.bob.wallet.balance = types.Quantity(amount=base_amount, unit=types.TokenType.BASE)
+        _, agent_deltas_open = self.hyperdrive.open_long(
+            agent_wallet=self.bob.wallet,
+            base_amount=base_amount,
+        )
+        self.verify_slippage(agent_deltas_open.balance.amount, base_amount)
+
+    def test_precision_long_close(self):
+        """Make sure we have slippage on a long open and close round trip"""
+        base_amount = 10
+        self.bob.budget = base_amount
+        self.bob.wallet.balance = types.Quantity(amount=base_amount, unit=types.TokenType.BASE)
+        _, agent_deltas_open = self.hyperdrive.open_long(
+            agent_wallet=self.bob.wallet,
+            base_amount=base_amount,
+        )
+        _, agent_deltas_close = self.hyperdrive.close_long(
+            agent_wallet=self.bob.wallet,
+            bond_amount=agent_deltas_open.longs[0].balance,
+            mint_time=0,
+        )
+        self.verify_slippage(agent_deltas_close.balance.amount, base_amount)
+
+    def test_precision_short_open(self):
+        """Make sure we have slippage on a short trade"""
+        trade_amount = 10  # this will be reflected in BASE in the wallet and PTs in the short
+        self.bob.budget = trade_amount
+        self.bob.wallet.balance = types.Quantity(amount=trade_amount, unit=types.TokenType.BASE)
+        _, agent_deltas_open = self.hyperdrive.open_short(
+            agent_wallet=self.bob.wallet,
+            bond_amount=trade_amount,
+        )
+        _, agent_deltas_close = self.hyperdrive.close_short(
+            agent_wallet=self.bob.wallet,
+            bond_amount=agent_deltas_open.shorts[0].balance,
+            mint_time=0,
+            open_share_price=1,
+        )
+        self.verify_slippage(agent_deltas_close.balance.amount, trade_amount)


### PR DESCRIPTION
* check that round trips have slippage
* use Decimal throughout the codebase, wth the following exceptions
 - config
 - block time (defined manually, never affected by pricing model)
 - mint_time (this is a reflection of block time)
 - weighted averages (because the amounts are weighted by time, a float)
* 