### PR TITLE
convert float to a float so accidentally creating an agent with a bud…

### DIFF
--- a/elfpy/agents/agent.py
+++ b/elfpy/agents/agent.py
@@ -51,7 +51,7 @@ class Agent:
         """Set up initial conditions"""
         self.budget: float = budget
         self.wallet: wallet.Wallet = wallet.Wallet(
-            address=wallet_address, balance=types.Quantity(amount=budget, unit=types.TokenType.BASE)
+            address=wallet_address, balance=types.Quantity(amount=float(budget), unit=types.TokenType.BASE)
         )
         # TODO: We need to fix this up -- probably just have the user specify a name on init
         # (i.e. attribute without default)


### PR DESCRIPTION
…get of int type, like 0 instead of 0.0, does not cause problems down the line, like with assertEqual failing because it receives an unexpected type