### PR TITLE
add remove liquidity tests

### DIFF
--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -138,7 +138,7 @@ class Wallet:
         for key, value_or_dict in wallet_deltas.copy().__dict__.items():
             if value_or_dict is None or key in ["fees_paid", "address", "frozen", "no_new_attribs"]:
                 continue
-            if key in ["lp_tokens", "fees_paid"]:
+            if key in ["lp_tokens", "fees_paid", "withdraw_shares"]:
                 logging.debug(
                     "agent #%g %s pre-trade = %.0g\npost-trade = %1g\ndelta = %1g",
                     self.address,
@@ -148,6 +148,8 @@ class Wallet:
                     value_or_dict,
                 )
                 self[key] += value_or_dict
+                if self[key] < 0:
+                    raise ValueError(f"{key} value less than zero")
             # handle updating a Quantity
             elif key == "balance":
                 logging.debug(

--- a/elfpy/agents/wallet.py
+++ b/elfpy/agents/wallet.py
@@ -1,16 +1,17 @@
 """Implements abstract classes that control user behavior"""
 from __future__ import annotations  # types will be strings by default in 3.11
 
-import logging
 import copy
-from typing import TYPE_CHECKING
+import logging
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.types as types
 
 if TYPE_CHECKING:
-    from typing import Iterable, Any
+    from typing import Any, Iterable
+
     import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 
 
@@ -105,6 +106,7 @@ class Wallet:
     # non-fungible (identified by key=mint_time, stored as dict)
     longs: dict[float, Long] = field(default_factory=dict)
     shorts: dict[float, Short] = field(default_factory=dict)
+    withdraw_shares: float = 0
     # borrow and  collateral have token type, which is not represented here
     # this therefore assumes that only one token type can be used at any given mint time
     borrows: dict[float, Borrow] = field(default_factory=dict)

--- a/elfpy/errors/errors.py
+++ b/elfpy/errors/errors.py
@@ -6,3 +6,15 @@ class InvalidCheckpointTime(Exception):
     If the checkpoint time isn't divisible by the checkpoint duration or is in the future, it's an
     invalid checkpoint and we should revert.
     """
+
+
+class OutputLimit(Exception):
+    """
+    If the output requirement is not met.  Often this is a minimum amount out as slippage protection.
+    """
+
+
+class UnsupportedOption(Exception):
+    """
+    If the output requirement is not met.  Often this is a minimum amount out as slippage protection.
+    """

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -463,20 +463,18 @@ def calc_remove_liquidity(
         market_state=market.market_state,
         time_remaining=market.position_duration,
     )
-
     # perform the trade
     delta_shares, delta_bonds = market.pricing_model.calc_tokens_out_given_lp_in(
         lp_in=lp_shares,
         market_state=market.market_state,
     )
     delta_base = market.market_state.share_price * delta_shares
-
     # calculate withdraw shares for the user
     user_margin = market.market_state.longs_outstanding - market.market_state.long_base_volume
     user_margin += market.market_state.short_base_volume
     user_margin = user_margin * lp_shares / market.market_state.lp_total_supply
     withdraw_shares = user_margin / market.market_state.share_price
-
+    # create and return the deltas
     market_deltas = MarketDeltas(
         d_base_asset=-delta_base,
         d_bond_asset=-delta_bonds,
@@ -489,7 +487,6 @@ def calc_remove_liquidity(
         lp_tokens=-lp_shares,
         withdraw_shares=withdraw_shares,
     )
-
     return market_deltas, agent_deltas
 
 

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -51,6 +51,7 @@ class MarketDeltas(base_market.MarketDeltas):
     short_average_maturity_time: float = 0
     long_base_volume: float = 0
     short_base_volume: float = 0
+    total_supply_withdraw_shares: float = 0
     withdraw_shares_ready_to_withdraw: float = 0
     withdraw_capital: float = 0
     withdraw_interest: float = 0

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -1,10 +1,10 @@
 """Market simulators store state information when interfacing AMM pricing models with users."""
 from __future__ import annotations  # types will be strings by default in 3.11
 
-from dataclasses import dataclass, field
 from collections import defaultdict
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 import elfpy.agents.wallet as wallet
 import elfpy.markets.base as base_market
@@ -51,10 +51,9 @@ class MarketDeltas(base_market.MarketDeltas):
     short_average_maturity_time: float = 0
     long_base_volume: float = 0
     short_base_volume: float = 0
-    long_withdrawal_shares_outstanding: float = 0
-    short_withdrawal_shares_outstanding: float = 0
-    long_withdrawal_share_proceeds: float = 0
-    short_withdrawal_share_proceeds: float = 0
+    withdraw_shares_ready_to_withdraw: float = 0
+    withdraw_capital: float = 0
+    withdraw_interest: float = 0
     long_checkpoints: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
     short_checkpoints: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))
     total_supply_longs: defaultdict[float, float] = field(default_factory=lambda: defaultdict(float))

--- a/elfpy/markets/hyperdrive/hyperdrive_actions.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_actions.py
@@ -465,7 +465,7 @@ def calc_remove_liquidity(
     )
 
     # perform the trade
-    delta_shares, delta_bonds = market.pricing_model.calc_shares_out_given_lp_in(
+    delta_shares, delta_bonds = market.pricing_model.calc_tokens_out_given_lp_in(
         lp_in=lp_shares,
         market_state=market.market_state,
     )

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -735,7 +735,7 @@ class Market(
         market_deltas.withdraw_interest -= float(recovered_interest)
 
         # Withdraw for the user
-        base_proceeds = self._withdraw(recovered_margin + recovered_interest, as_underlying)
+        base_proceeds = self._withdraw(float(recovered_margin + recovered_interest), as_underlying)
         # TODO: figure out how to keep track of hyperdrive's base asset amount.  market_deltas has
         # a d_base_asset, but that is used to update the share_reserves :/.
         # market_deltas.d_base_asset -= base_proceeds

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -6,7 +6,6 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import Union
 
 import numpy as np
 
@@ -15,7 +14,6 @@ import elfpy.errors.errors as errors
 import elfpy.markets.base as base_market
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
-import elfpy.pricing_models.yieldspace as yieldspace_pm
 import elfpy.time as time
 import elfpy.types as types
 import elfpy.utils.price as price_utils

--- a/elfpy/markets/hyperdrive/hyperdrive_market.py
+++ b/elfpy/markets/hyperdrive/hyperdrive_market.py
@@ -231,7 +231,7 @@ class Market(
     base_market.Market[
         MarketState,
         hyperdrive_actions.MarketDeltas,
-        Union[hyperdrive_pm.HyperdrivePricingModel, yieldspace_pm.YieldspacePricingModel],
+        hyperdrive_pm.HyperdrivePricingModel,
     ]
 ):
     r"""Market state simulator
@@ -243,7 +243,7 @@ class Market(
 
     def __init__(
         self,
-        pricing_model: hyperdrive_pm.HyperdrivePricingModel | yieldspace_pm.YieldspacePricingModel,
+        pricing_model: hyperdrive_pm.HyperdrivePricingModel,
         market_state: MarketState,
         position_duration: time.StretchedTime,
         block_time: time.BlockTime,

--- a/elfpy/pricing_models/base.py
+++ b/elfpy/pricing_models/base.py
@@ -1,9 +1,9 @@
 """The base pricing model"""
 from __future__ import annotations  # types will be strings by default in 3.11
 
+import logging
 from abc import ABC
 from decimal import Decimal, getcontext
-import logging
 from typing import TYPE_CHECKING
 
 import elfpy.pricing_models.trades as trades
@@ -69,9 +69,7 @@ class PricingModel(ABC):
     def calc_tokens_out_given_lp_in(
         self,
         lp_in: float,
-        rate: float,
         market_state: hyperdrive_market.MarketState,
-        time_remaining: time.StretchedTime,
     ) -> tuple[float, float, float]:
         """Calculate how many tokens should be returned for a given lp addition"""
         raise NotImplementedError

--- a/elfpy/pricing_models/hyperdrive.py
+++ b/elfpy/pricing_models/hyperdrive.py
@@ -353,14 +353,11 @@ class HyperdrivePricingModel(YieldspacePricingModel):
         percent_of_lp_shares = lp_in / market_state.lp_total_supply
         # dz = (z - o_l / c) * (dl / l)
         shares_delta = (
-            abs(market_state.share_reserves - market_state.longs_outstanding / market_state.share_price)
-            * percent_of_lp_shares
-        )
-
-        bonds_delta = abs(
+            market_state.share_reserves - market_state.longs_outstanding / market_state.share_price
+        ) * percent_of_lp_shares
+        bonds_delta = (
             market_state.bond_reserves
             - market_state.bond_reserves * (market_state.share_reserves - shares_delta) / market_state.share_reserves
         )
-
         # these are both positive values
         return shares_delta, bonds_delta

--- a/elfpy/pricing_models/hyperdrive.py
+++ b/elfpy/pricing_models/hyperdrive.py
@@ -4,12 +4,12 @@ from __future__ import annotations  # types will be strings by default in 3.11
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from elfpy.pricing_models.yieldspace import YieldspacePricingModel
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.pricing_models.trades as trades
 import elfpy.time as time
-from elfpy.agents.agent import AgentTradeResult
 import elfpy.types as types
+from elfpy.agents.agent import AgentTradeResult
+from elfpy.pricing_models.yieldspace import YieldspacePricingModel
 
 if TYPE_CHECKING:
     import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
@@ -327,3 +327,39 @@ class HyperdrivePricingModel(YieldspacePricingModel):
                 gov_redemption_fee=float(gov_redemption_fee),
             ),
         )
+
+    def calc_shares_out_given_lp_in(
+        self, lp_in: float, market_state: hyperdrive_market.MarketState
+    ) -> tuple[float, float]:
+        """
+        Calculates the amount of base shares and bonds released from burning a a specified amount of
+        LP shares from the pool.
+
+        Parameters
+        ----------
+        lp_in: float
+            The amount of lp shares that are given back to the pool
+        market_state : MarketState
+            The state of the AMM's reserves and share prices.
+
+        Returns
+        -------
+        float
+            The amount of shares taken out of reserves
+        float
+            The amount of bonds taken out of reserves
+        """
+        # get the shares out to the user
+        percent_of_lp_shares = lp_in / market_state.lp_total_supply
+        # dz = (z - o_l / c) * (dl / l)
+        shares_delta = (
+            market_state.share_reserves - market_state.longs_outstanding / market_state.share_price
+        ) * percent_of_lp_shares
+
+        bonds_delta = (
+            market_state.bond_reserves
+            - market_state.bond_reserves * (market_state.share_reserves - shares_delta) / market_state.share_reserves
+        )
+
+        # these are both positive values
+        return shares_delta, bonds_delta

--- a/elfpy/pricing_models/hyperdrive.py
+++ b/elfpy/pricing_models/hyperdrive.py
@@ -328,7 +328,7 @@ class HyperdrivePricingModel(YieldspacePricingModel):
             ),
         )
 
-    def calc_shares_out_given_lp_in(
+    def calc_tokens_out_given_lp_in(
         self, lp_in: float, market_state: hyperdrive_market.MarketState
     ) -> tuple[float, float]:
         """

--- a/elfpy/pricing_models/hyperdrive.py
+++ b/elfpy/pricing_models/hyperdrive.py
@@ -332,7 +332,7 @@ class HyperdrivePricingModel(YieldspacePricingModel):
         self, lp_in: float, market_state: hyperdrive_market.MarketState
     ) -> tuple[float, float]:
         """
-        Calculates the amount of base shares and bonds released from burning a a specified amount of
+        Calculates the amount of base shares and bonds released from burning a specified amount of
         LP shares from the pool.
 
         Parameters
@@ -353,10 +353,11 @@ class HyperdrivePricingModel(YieldspacePricingModel):
         percent_of_lp_shares = lp_in / market_state.lp_total_supply
         # dz = (z - o_l / c) * (dl / l)
         shares_delta = (
-            market_state.share_reserves - market_state.longs_outstanding / market_state.share_price
-        ) * percent_of_lp_shares
+            abs(market_state.share_reserves - market_state.longs_outstanding / market_state.share_price)
+            * percent_of_lp_shares
+        )
 
-        bonds_delta = (
+        bonds_delta = abs(
             market_state.bond_reserves
             - market_state.bond_reserves * (market_state.share_reserves - shares_delta) / market_state.share_reserves
         )

--- a/elfpy/pricing_models/yieldspace.py
+++ b/elfpy/pricing_models/yieldspace.py
@@ -841,3 +841,39 @@ class YieldspacePricingModel(PricingModel):
         return (share_price / init_share_price) * (init_share_price * share_reserves) ** time_elapsed + (
             bond_reserves + lp_total_supply
         ) ** time_elapsed
+
+    def calc_shares_out_given_lp_in(
+        self, lp_in: float, market_state: hyperdrive_market.MarketState
+    ) -> tuple[float, float]:
+        """
+        Calculates the amount of base shares and bonds released from burning a a specified amount of
+        LP shares from the pool.
+
+        Parameters
+        ----------
+        lp_in: float
+            The amount of lp shares that are given back to the pool
+        market_state : MarketState
+            The state of the AMM's reserves and share prices.
+
+        Returns
+        -------
+        float
+            The amount of shares taken out of reserves
+        float
+            The amount of bonds taken out of reserves
+        """
+        # get the shares out to the user
+        percent_of_lp_shares = lp_in / market_state.lp_total_supply
+        # dz = (z - o_l / c) * (dl / l)
+        shares_delta = (
+            market_state.share_reserves - market_state.longs_outstanding / market_state.share_price
+        ) * percent_of_lp_shares
+
+        bonds_delta = (
+            market_state.bond_reserves
+            - market_state.bond_reserves * (market_state.share_reserves - shares_delta) / market_state.share_reserves
+        )
+
+        # these are both positive values
+        return shares_delta, bonds_delta

--- a/elfpy/pricing_models/yieldspace.py
+++ b/elfpy/pricing_models/yieldspace.py
@@ -1,16 +1,16 @@
 """The YieldSpace pricing model"""
 from __future__ import annotations  # types will be strings by default in 3.11
 
-from decimal import Decimal
 import logging
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from elfpy.pricing_models.base import PricingModel
-import elfpy.time as time
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
-from elfpy.agents.agent import AgentTradeResult
 import elfpy.pricing_models.trades as trades
+import elfpy.time as time
 import elfpy.types as types
+from elfpy.agents.agent import AgentTradeResult
+from elfpy.pricing_models.base import PricingModel
 
 if TYPE_CHECKING:
     import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market

--- a/elfpy/simulators/simulators.py
+++ b/elfpy/simulators/simulators.py
@@ -10,15 +10,15 @@ import numpy as np
 import pandas as pd
 from numpy.random._generator import Generator as NumpyGenerator
 
-import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.agents.wallet as wallet
+import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.time as time
 import elfpy.types as types
 import elfpy.utils.outputs as output_utils
 
 if TYPE_CHECKING:
-    from elfpy.agents.agent import Agent
     import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
+    from elfpy.agents.agent import Agent
 
 
 @dataclass

--- a/elfpy/types.py
+++ b/elfpy/types.py
@@ -1,9 +1,10 @@
 """Core types used across the repo"""
 from __future__ import annotations  # types will be strings by default in 3.11
-from enum import Enum
+
 from dataclasses import dataclass
+from enum import Enum
 from functools import wraps
-from typing import Type, Any
+from typing import Any, Type
 
 
 def freezable(frozen: bool = False, no_new_attribs: bool = False) -> Type:
@@ -56,6 +57,7 @@ class TokenType(Enum):
 
     BASE = "base"
     PT = "pt"
+    LP_SHARE = "lp_share"
 
 
 @dataclass

--- a/elfpy/utils/sim_utils.py
+++ b/elfpy/utils/sim_utils.py
@@ -5,15 +5,15 @@ import logging
 from importlib import import_module
 from typing import TYPE_CHECKING, Optional
 
-import elfpy.simulators as simulators
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
-import elfpy.time as time
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
 import elfpy.pricing_models.yieldspace as yieldspace_pm
+import elfpy.simulators as simulators
+import elfpy.time as time
 
 if TYPE_CHECKING:
-    import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
     import elfpy.agents.wallet as wallet
+    import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
     from elfpy.agents.agent import Agent
     from elfpy.agents.policies.no_action import Policy
 
@@ -40,7 +40,9 @@ def get_simulator(
     """
     config.check_variable_apr()  # quick check to make sure the vault apr is correctly set
     # Instantiate the market.
-    pricing_model = get_pricing_model(config.pricing_model_name)
+    # pricing model is hardcoded for now.  once we have support for more markets, we can add a
+    # config option for type of market
+    pricing_model = hyperdrive_pm.HyperdrivePricingModel()
     block_time = time.BlockTime()
     market, init_agent_deltas, market_deltas = get_initialized_hyperdrive_market(pricing_model, block_time, config)
     simulator = simulators.Simulator(config=config, market=market, block_time=block_time)
@@ -101,7 +103,7 @@ def get_simulator(
 
 
 def get_initialized_hyperdrive_market(
-    pricing_model: hyperdrive_pm.HyperdrivePricingModel | yieldspace_pm.YieldspacePricingModel,
+    pricing_model: hyperdrive_pm.HyperdrivePricingModel,
     block_time: time.BlockTime,
     config: simulators.Config,
 ) -> tuple[hyperdrive_market.Market, wallet.Wallet, hyperdrive_actions.MarketDeltas]:

--- a/tests/solidity/test_add_liquidity.py
+++ b/tests/solidity/test_add_liquidity.py
@@ -152,7 +152,7 @@ class TestAddLiquidity(unittest.TestCase):
         # Ensure that if the new LP withdraws, they get their money back.
         market_deltas, wallet_deltas = self.hyperdrive.remove_liquidity(
             agent_wallet=self.bob.wallet,
-            bond_amount=self.bob.wallet.lp_tokens,
+            lp_shares=self.bob.wallet.lp_tokens,
         )
         self.assertAlmostEqual(wallet_deltas.balance.amount, self.contribution, places=6)
 
@@ -187,6 +187,6 @@ class TestAddLiquidity(unittest.TestCase):
         # Ensure that if the new LP withdraws, they get their money back.
         market_deltas, wallet_deltas = self.hyperdrive.remove_liquidity(
             agent_wallet=self.bob.wallet,
-            bond_amount=self.bob.wallet.lp_tokens,
+            lp_shares=self.bob.wallet.lp_tokens,
         )
         self.assertAlmostEqual(wallet_deltas.balance.amount, self.contribution)

--- a/tests/solidity/test_remove_liquidity.py
+++ b/tests/solidity/test_remove_liquidity.py
@@ -1,0 +1,158 @@
+"""Remove liquidity market trade tests that match those being executed in the solidity repo"""
+import unittest
+
+import numpy
+
+import elfpy.agents.agent as agent
+import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
+import elfpy.pricing_models.hyperdrive as hyperdrive_pm
+import elfpy.time as time
+
+# pylint: disable=too-many-arguments
+# pylint: disable=duplicate-code
+
+
+class TestRemoveLiquidity(unittest.TestCase):
+    """Test opening a long in hyperdrive"""
+
+    contribution: float = 500_000_000
+    target_apr: float = 0.05
+    term_length: int = 365
+    alice: agent.Agent
+    bob: agent.Agent
+    celine: agent.Agent
+    hyperdrive: hyperdrive_market.Market
+    block_time: time.BlockTime
+
+    def setUp(self):
+        """Set up agent, pricing model, & market for the subsequent tests.
+        This function is run before each test method.
+        """
+        self.alice = agent.Agent(wallet_address=0, budget=self.contribution)
+        self.bob = agent.Agent(wallet_address=1, budget=self.contribution)
+        self.celine = agent.Agent(wallet_address=2, budget=self.contribution)
+        self.block_time = time.BlockTime()
+        pricing_model = hyperdrive_pm.HyperdrivePricingModel()
+        market_state = hyperdrive_market.MarketState(
+            trade_fee_percent=0.0,
+            redemption_fee_percent=0.0,
+        )
+        self.hyperdrive = hyperdrive_market.Market(
+            pricing_model=pricing_model,
+            market_state=market_state,
+            position_duration=time.StretchedTime(
+                days=self.term_length,
+                time_stretch=pricing_model.calc_time_stretch(self.target_apr),
+                normalizing_constant=self.term_length,
+            ),
+            block_time=self.block_time,
+        )
+        _, wallet_deltas = self.hyperdrive.initialize(self.alice.wallet.address, self.contribution, self.target_apr)
+        self.alice.wallet.update(wallet_deltas)
+
+    def test_remove_liquidity_fail_zero_amount(self):
+        """Should fail to remove zero liquidity"""
+        with self.assertRaises(AssertionError):
+            self.hyperdrive.remove_liquidity(self.alice.wallet, 0)
+
+    def test_remove_liquidity_fail_insufficient_shares(self):
+        """Should fail to remove more liquidity than the agent has"""
+        with self.assertRaises(ValueError):
+            self.hyperdrive.remove_liquidity(self.alice.wallet, self.alice.wallet.lp_tokens + 1)
+
+    def test_remove_liquidity_no_trades(self):
+        """Should remove liquidity if there are no open trades"""
+
+        # advance time and let interest accrue
+        self.block_time.set_time(1)
+
+        # compund interest = p * e ^(rate * time)
+        # we advance by one year, and the rate is .05 / year
+        accrued = self.contribution * numpy.exp(self.target_apr * 1)
+        self.hyperdrive.market_state.share_price = accrued / self.contribution
+
+        # alice removes all liquidity
+        self.hyperdrive.remove_liquidity(self.alice.wallet, self.alice.wallet.lp_tokens)
+
+        # make sure all alice's lp tokens were burned
+        self.assertEqual(self.alice.wallet.lp_tokens, 0)
+        self.assertEqual(self.hyperdrive.market_state.lp_total_supply, 0)
+
+        # make sure pool balances went to zero
+        self.assertEqual(self.hyperdrive.market_state.share_reserves, 0)
+        self.assertEqual(self.hyperdrive.market_state.bond_reserves, 0)
+
+        # there should be no withdraw shares since no margin was locked up
+        self.assertEqual(self.alice.wallet.withdraw_shares, 0)
+
+    def test_remove_liquidity_long_trade(self):
+        """Should remove liquidity if there are open longs"""
+        market_state = self.hyperdrive.market_state
+
+        # advance time and let interest accrue
+        self.block_time.set_time(1)
+
+        # compund interest = p * e ^(rate * time)
+        # we advance by one year, and the rate is .05 / year
+        accrued = self.contribution * numpy.exp(self.target_apr * 1)
+        market_state.share_price = accrued / self.contribution
+
+        # bob opens a long
+        base_amount = 50_000_000
+        long_market_deltas, _ = self.hyperdrive.open_long(self.bob.wallet, base_amount)
+        bond_amount = long_market_deltas.d_bond_asset
+
+        # alice removes all liquidity
+        _, remove_wallet_deltas = self.hyperdrive.remove_liquidity(self.alice.wallet, self.alice.wallet.lp_tokens)
+        base_proceeds = remove_wallet_deltas.balance.amount
+
+        # make sure all alice's lp tokens were burned
+        self.assertEqual(self.alice.wallet.lp_tokens, 0)
+        self.assertEqual(market_state.lp_total_supply, 0)
+
+        base_expected = accrued + base_amount - bond_amount
+        self.assertAlmostEqual(base_proceeds, base_expected, 8)
+
+        # make sure pool balances went to zero
+        self.assertEqual(market_state.share_reserves, 0)
+        self.assertEqual(market_state.bond_reserves, 0)
+
+        # ensure correct amount of withdrawal shares
+        withdraw_shares_expected = market_state.long_base_volume / market_state.share_price
+        self.assertEqual(self.alice.wallet.withdraw_shares, withdraw_shares_expected)
+
+    def test_remove_liquidity_short_trade(self):
+        """Should remove liquidity if there are open shorts"""
+        market_state = self.hyperdrive.market_state
+
+        # advance time and let interest accrue
+        self.block_time.set_time(1)
+
+        # compund interest = p * e ^(rate * time)
+        # we advance by one year, and the rate is .05 / year
+        accrued = self.contribution * numpy.exp(self.target_apr * 1)
+        market_state.share_price = accrued / self.contribution
+
+        # bob opens a short
+        short_amount_bonds = 50_000_000
+        long_market_deltas, _ = self.hyperdrive.open_short(self.bob.wallet, short_amount_bonds)
+        bond_amount = long_market_deltas.d_bond_asset
+
+        # alice removes all liquidity
+        _, remove_wallet_deltas = self.hyperdrive.remove_liquidity(self.alice.wallet, self.alice.wallet.lp_tokens)
+        base_proceeds = remove_wallet_deltas.balance.amount
+
+        # make sure all alice's lp tokens were burned
+        self.assertEqual(self.alice.wallet.lp_tokens, 0)
+        self.assertEqual(market_state.lp_total_supply, 0)
+
+        base_expected = accrued + short_amount_bonds - bond_amount
+        self.assertAlmostEqual(base_proceeds, base_expected, 8)
+
+        # make sure pool balances went to zero
+        self.assertEqual(market_state.share_reserves, 0)
+        self.assertEqual(market_state.bond_reserves, 0)
+
+        # ensure correct amount of withdrawal shares
+        withdraw_shares_expected = market_state.short_base_volume / market_state.share_price
+        self.assertEqual(self.alice.wallet.withdraw_shares, withdraw_shares_expected)

--- a/tests/test_borrow.py
+++ b/tests/test_borrow.py
@@ -1,15 +1,15 @@
 """Testing the Borrow Market"""
 
-import logging
 import itertools
+import logging
 import unittest
 
 import numpy as np
 
+import elfpy.markets.borrow as borrow_market
 import elfpy.time as time
 import elfpy.types as types
 import elfpy.utils.outputs as output_utils
-import elfpy.markets.borrow as borrow_market
 
 
 class TestBorrow(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestBorrow(unittest.TestCase):
         """Borrow 100 BASE"""
         output_utils.setup_logging(log_filename=".logging/test_borrow.log", log_level=logging.DEBUG)
         for loan_to_value, collateral_exponent, collateral_token in itertools.product(
-            range(1, 100, 5), range(0, 8, 2), types.TokenType
+            range(1, 100, 5), range(0, 8, 2), [types.TokenType.BASE, types.TokenType.PT]
         ):
             spot_price_range = [1]
             if collateral_token == types.TokenType.PT:

--- a/tests/utils/test_sim_utils.py
+++ b/tests/utils/test_sim_utils.py
@@ -9,7 +9,6 @@ import numpy as np
 import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
 import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
-import elfpy.pricing_models.yieldspace as yieldspace_pm
 import elfpy.simulators.simulators as simulators
 import elfpy.time as time
 import elfpy.utils.outputs as output_utils

--- a/tests/utils/test_sim_utils.py
+++ b/tests/utils/test_sim_utils.py
@@ -6,14 +6,14 @@ import unittest
 
 import numpy as np
 
+import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
+import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
 import elfpy.pricing_models.hyperdrive as hyperdrive_pm
 import elfpy.pricing_models.yieldspace as yieldspace_pm
 import elfpy.simulators.simulators as simulators
-import elfpy.markets.hyperdrive.hyperdrive_market as hyperdrive_market
-import elfpy.markets.hyperdrive.hyperdrive_actions as hyperdrive_actions
+import elfpy.time as time
 import elfpy.utils.outputs as output_utils
 import elfpy.utils.sim_utils as sim_utils
-import elfpy.time as time
 
 # pylint: disable=too-many-locals
 
@@ -27,7 +27,7 @@ class SimUtilsTest(unittest.TestCase):
         for target_liquidity in (1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9):
             for target_fixed_apr in (0.01, 0.03, 0.05, 0.10, 0.25, 0.5, 1, 1.1):
                 for num_position_days in [90, 365]:
-                    for pricing_model_name in ["Yieldspace", "Hyperdrive"]:
+                    for pricing_model_name in ["Hyperdrive"]:
                         config = simulators.Config()
                         config.pricing_model_name = pricing_model_name
                         config.target_liquidity = target_liquidity
@@ -40,10 +40,7 @@ class SimUtilsTest(unittest.TestCase):
                         config.num_position_days = num_position_days
                         # construct the market via sim utils
                         block_time = time.BlockTime()
-                        if pricing_model_name.lower() == "hyperdrive":
-                            pricing_model = hyperdrive_pm.HyperdrivePricingModel()
-                        else:
-                            pricing_model = yieldspace_pm.YieldspacePricingModel()
+                        pricing_model = hyperdrive_pm.HyperdrivePricingModel()
                         market, _, _ = sim_utils.get_initialized_hyperdrive_market(pricing_model, block_time, config)
                         # then construct it by hand
                         market_direct = hyperdrive_market.Market(


### PR DESCRIPTION
This PR adds the equivalent remove liquidity tests in python for hyperdrive.  It also contains a fair amount of the code needed to complete the fair withdrawal shares, though some will need to be added when closing longs/shorts.  
