### PR TITLE
allow URLs to pass line limit

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -326,7 +326,7 @@ redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
 expected-line-ending-format=
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+ignore-long-lines=^.*(# )?<?https?://\S+>?$
 
 # Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4


### PR DESCRIPTION
default pylint setting allows URLs to pass the line limit, but only if they're the only thing in the comment.
we want a more permissive regex which captures lines in our docstrings where the URL is at the end of the line.

old and busted
![image](https://user-images.githubusercontent.com/16990562/233251982-3827a8c3-4f36-4103-8817-ada4f1d4600f.png)

new hotness
![image](https://user-images.githubusercontent.com/16990562/233252014-1db80f0b-740f-4028-a587-11ef8ea57665.png)
